### PR TITLE
Basic proxy support

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -224,6 +224,9 @@ module Excon
     def setup_proxy(proxy)
       proxy = 'http://' << proxy unless proxy.index('://')
       uri = URI.parse(proxy)
+      unless uri.host and uri.port and uri.scheme
+        raise Excon::Errors::ProxyParseError, "Proxy is invalid"
+      end
       @proxy = {
         :host     => uri.host,
         :port     => uri.port,

--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -13,6 +13,8 @@ module Excon
       end
     end
 
+    class ProxyParseError < Error; end
+
     class HTTPStatusError < Error
       attr_reader :request, :response
 


### PR DESCRIPTION
Adds support for basic proxies via the :proxy param. Example:

Excon.connection('http://www.google.com', :proxy => 'http://localhost:8888').request(:method => 'GET')

https proxies not supported yet, that support coming in another patch.

Submitting as two commits so you can cherry-pick regarding exception raising on bad proxies.
