### PR TITLE
Header Splits Too Eagerly

### DIFF
--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -13,7 +13,7 @@ module Excon
       block_given = block_given?
 
       until ((data = socket.readline).chop!).empty?
-        key, value = data.split(': ')
+        key, value = data.split(': ', 2)
         response.headers[key] = value
         if key.casecmp('Content-Length') == 0
           content_length = value.to_i

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -31,6 +31,10 @@ with_rackup('basic.ru') do
         !!(response.headers['Server'] =~ /^WEBrick/)
       end
 
+      test("response.headers['Custom']").returns("Foo: bar") do
+        response.headers['Custom']
+      end
+
       tests("response.body").returns('x' * 100) do
         response.body
       end

--- a/tests/rackups/basic.ru
+++ b/tests/rackups/basic.ru
@@ -2,6 +2,7 @@ require 'sinatra'
 
 class App < Sinatra::Base
   get '/content-length/:value' do |value|
+    headers "Custom" => "Foo: bar"
     'x' * value.to_i
   end
 end


### PR DESCRIPTION
I have a service I'm hitting that returns an HTTP header like this:

```
Header: Foo: bar Baz: bing
```

I kid you not. But hey, whatever, no big deal. Unfortunately, Excon doesn't handle this case, splitting very eagerly on _every_ occurrence of `': '` (colon and space), instead of just the first one.

This patch should fix that.

Now, regarding the tests... I don't know if they work. It should: they are really simple, and it's not a drastic change. However, I was never able to get them to work. When I ran `rake test`, it ran without any error and produced no output, finishing unusually fast, and returning `0`. When I try to run the tests in Textmate, I get the following error:

```
NoMethodError: undefined method ‘display_error’ for #<Shindo::Tests:0x1025d54f0>
```

Let me know if you need anything else. I wasn't really able to figure out how to get the tests working, though I'd love to make sure what I wrote actually works. (So, obviously, please check that it does. I'm tired and might have even fucked this up, lol.)

Cheers!
