### PR TITLE
Force encoding

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -4,7 +4,7 @@ module Excon
 
     CR_NL     = "\r\n"
     HTTP_1_1  = " HTTP/1.1\r\n"
-    FORCE_ENC = String.respond_to?(:force_encoding)
+    FORCE_ENC = CR_NL.respond_to?(:force_encoding)
 
     # Initializes a new Connection instance
     #   @param [String] url The destination URL


### PR DESCRIPTION
String class doesn't respond to :force_encoding, but an instance will. (Minor error that might cause POST/PUT bodies to be truncated improperly by a server.)
