### PR TITLE
SSL Client Certificates

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -193,6 +193,11 @@ module Excon
           ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
 
+        if @connection.has_key?(:client_cert) && @connection.has_key?(:client_key)
+          ssl_context.cert = OpenSSL::X509::Certificate.new(File.read(@connection[:client_cert]))
+          ssl_context.key = OpenSSL::PKey::RSA.new(File.read(@connection[:client_key]))
+        end
+
         # open ssl socket
         new_socket = OpenSSL::SSL::SSLSocket.new(new_socket, ssl_context)
         new_socket.sync_close = true


### PR DESCRIPTION
This is just enough to support client certs. 
There's a caveat though, which is that presently they only work if one creates a new Excon object and then calls #request, rather than using the convenience methods.
This is because the convenience methods pass params at #request time, rather than to #initialize, and so #connect never sees them.
I'm not sure how to fix that.
-Thom
