### PR TITLE
Don't calculate Content-Length header if it is already set

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -81,7 +81,7 @@ module Excon
         request << HTTP_1_1
 
         # calculate content length and set to handle non-ascii
-        params[:headers]['Content-Length'] = case params[:body]
+        params[:headers]['Content-Length'] ||= case params[:body]
         when File
           params[:body].binmode
           File.size(params[:body])


### PR DESCRIPTION
The Content-Length calculation code is tightly tied to String/File at the moment. This simple change lets the caller calculate the content-length for non String/File objects that need to be streamed. 
