### PR TITLE
Yield the content length to the chunking block when able to

### DIFF
--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -42,9 +42,15 @@ module Excon
           elsif connection_close
             yield socket.read
           else
+            yield_content_length = Proc.new.arity != 1
             remaining = content_length
             while remaining > 0
-              yield socket.read([CHUNK_SIZE, remaining].min)
+              chunk = socket.read([CHUNK_SIZE, remaining].min)
+              if yield_content_length
+                yield chunk, content_length
+              else
+                yield chunk
+              end
               remaining -= CHUNK_SIZE
             end
           end


### PR DESCRIPTION
This is useful for progress checks when downloading files. Written so as to be
backwards compatible with the previous method.
