### PR TITLE
Invalid param to yield() in Response#parse when block is given and connection closes

### DIFF
--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -49,7 +49,8 @@ module Excon
             end
             socket.read(2)
           elsif connection_close
-            yield(socket.read, remaining, content_length)
+            remaining = socket.read
+            yield(remaining, remaining.length, content_length)
           else
             remaining = content_length
             while remaining > 0


### PR DESCRIPTION
Use of a non-existent variable 'remaining'.  Looks like a simple fix.
