### PR TITLE
Fix header parsing so it properly parses all headers as allowed by RFC 2616

### DIFF
--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -23,7 +23,7 @@ module Excon
       block_given = block_given?
 
       until ((data = socket.readline).chop!).empty?
-        key, value = data.split(': ', 2)
+        key, value = data.split(/:\s*/, 2)
         response.headers[key] = ([*response.headers[key]] << value).compact.join(', ')
         if key.casecmp('Content-Length') == 0
           content_length = value.to_i


### PR DESCRIPTION
Fix header parsing so it properly parses all headers as allowed by RFC 2616.

To quote RFC 2616 section 4.2:

"Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive. The field value MAY be preceded by any amount of LWS [linear white space], though a single SP is preferred."

Previously, Excon only parsed headers of the preferred form properly.

I tried to write a test for this, but all your existing tests are using sinatra apps, which emit headers in the preferred form....so there wasn't an easy way to make a test case when a header is in the allowed-but-not-preferred form.
