### PR TITLE
Reset body.pos on request retry

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -185,6 +185,9 @@ module Excon
         retries_remaining ||= 4
         retries_remaining -= 1
         if retries_remaining > 0
+          if params[:body].respond_to?(:pos=)
+            params[:body].pos = 0
+          end
           retry
         else
           raise(request_error)


### PR DESCRIPTION
If an idempotent request is retried and body responds to `#pos=`, then reset the body position to 0.
