### PR TITLE
Don't do post_connection_check on an ssl connection if verify_mode is VER

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -263,7 +263,7 @@ module Excon
 
       new_socket.connect
       # verify connection
-      if ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+      if Excon.ssl_verify_peer
         new_socket.post_connection_check(@connection[:host])
       end
       new_socket


### PR DESCRIPTION
Don't do post_connection_check on an ssl connection if verify_mode is VERIFY_NONE. Otherwise an unwanted exception will be raised for misconfigured certificates.
