### PR TITLE
Config is deprecated and replaced by RbConfig

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -28,7 +28,7 @@ module Excon
     attr_reader :ssl_verify_peer
 
     # setup ssl defaults based on platform
-    @ssl_verify_peer = Config::CONFIG['host_os'] !~ /mswin|win32|dos|cygwin|mingw/i
+    @ssl_verify_peer = RbConfig::CONFIG['host_os'] !~ /mswin|win32|dos|cygwin|mingw/i
 
     # default mocking to off
     @mock = false


### PR DESCRIPTION
Removes the "Use RbConfig instead of obsolete and deprecated Config." deprecation warning when using ruby head
