### PR TITLE
Tests and fix to ensure idempotent requests are retried

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -190,7 +190,7 @@ module Excon
       end
 
     rescue => request_error
-      if params[:idempotent] && [Excon::Errors::SocketError, Excon::Errors::HTTPStatusError].include?(request_error)
+      if params[:idempotent] && [Excon::Errors::SocketError, Excon::Errors::HTTPStatusError].any? {|ex| request_error.kind_of? ex }
         retries_remaining ||= 4
         retries_remaining -= 1
         if retries_remaining > 0

--- a/tests/idempotent_tests.rb
+++ b/tests/idempotent_tests.rb
@@ -1,0 +1,56 @@
+Shindo.tests('Excon request idempotencey') do
+  Excon.mock = true
+
+  tests("Non-idempotent call with an erroring socket").raises(Excon::Errors::SocketError) do
+    Excon.stub({:method => :get}) { |params|
+      run_count += 1
+      if run_count < 4 # First 3 calls fail.
+        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+      else
+        {:body => params[:body], :headers => params[:headers], :status => 200}
+      end
+    }
+
+    connection = Excon.new('http://127.0.0.1:9292')
+    response = connection.request(:method => :get, :path => '/some-path')
+  end
+
+  Excon.stubs.pop
+
+  tests("Idempotent request with socket erroring first 3 times").returns(200) do
+    run_count = 0
+    Excon.stub({:method => :get}) { |params|
+      run_count += 1
+      if run_count <= 3 # First 3 calls fail.
+        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+      else
+        {:body => params[:body], :headers => params[:headers], :status => 200}
+      end
+    }
+
+    connection = Excon.new('http://127.0.0.1:9292')
+    response = connection.request(:method => :get, :idempotent => true, :path => '/some-path')
+    response.status
+  end
+
+  Excon.stubs.pop
+
+  tests("Idempotent request with socket erroring first 5 times").raises(Excon::Errors::SocketError) do
+    run_count = 0
+    Excon.stub({:method => :get}) { |params|
+      run_count += 1
+      if run_count <= 5 # First 5 calls fail.
+        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+      else
+        {:body => params[:body], :headers => params[:headers], :status => 200}
+      end
+    }
+
+    connection = Excon.new('http://127.0.0.1:9292')
+    response = connection.request(:method => :get, :idempotent => true, :path => '/some-path')
+    response.status
+  end
+
+  Excon.stubs.pop
+  Excon.mock = false
+end


### PR DESCRIPTION
The idempotent functionality in excon wasn't checking the exception types correctly, so wasn't working. This became evident in fog when EC2 error rates increased. This fixes this in fog, and once a new release is done will fig the fog bug: https://github.com/geemus/fog/issues/382
