### PR TITLE
Fix Socket#write to properly drain the buffer.

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -56,9 +56,10 @@ module Excon
       until @write_buffer.empty?
         begin
           max_length = [@write_buffer.length, Excon::CHUNK_SIZE].min
-          @socket.write_nonblock(@write_buffer.slice!(0, max_length))
+          written = @socket.write_nonblock(@write_buffer.slice(0, max_length))
+          @write_buffer.slice!(0, written)
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK
-          if IO.select(nil [@socket], nil, @connection_params[:write_timeout])
+          if IO.select(nil, [@socket], nil, @connection_params[:write_timeout])
             retry
           else
             raise(Timeout::Error)

--- a/tests/rackups/basic.ru
+++ b/tests/rackups/basic.ru
@@ -5,6 +5,10 @@ class App < Sinatra::Base
     headers("Custom" => "Foo: bar")
     'x' * value.to_i
   end
+
+  post('/body-sink') do
+    request.body.read.size.to_s
+  end
 end
 
 run App

--- a/tests/rackups/ssl.ru
+++ b/tests/rackups/ssl.ru
@@ -8,6 +8,10 @@ class App < Sinatra::Base
     headers("Custom" => "Foo: bar")
     'x' * value.to_i
   end
+
+  post('/body-sink') do
+    request.body.read.size.to_s
+  end
 end
 
 Rack::Handler::WEBrick.run(App, {

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -48,6 +48,17 @@ def basic_tests(url = 'http://127.0.0.1:9292')
       end
       data
     end
+
+  end
+
+  tests('POST /body-sink') do
+
+    connection = Excon.new(url)
+    response = connection.request(:method => :post, :path => '/body-sink', :body => 'x' * 5_000_000)
+
+    tests('response.body').returns("5000000") do
+      response.body
+    end
   end
 end
 


### PR DESCRIPTION
We can't assume `write_nonblock` has written as much as we've asked it to.

Also fix a problem in the `rescue`.
