### PR TITLE
Rescue Timeout::Error so it's retried on idempotent requests.

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -6,7 +6,6 @@ require 'forwardable'
 require 'openssl'
 require 'rbconfig'
 require 'socket'
-require 'timeout'
 require 'uri'
 
 require 'excon/constants'

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -182,7 +182,7 @@ module Excon
         response
       rescue Excon::Errors::StubNotFound => stub_not_found
         raise(stub_not_found)
-      rescue StandardError, Timeout::Error => socket_error
+      rescue => socket_error
         reset
         raise(Excon::Errors::SocketError.new(socket_error))
       end

--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -17,6 +17,8 @@ module Excon
       end
     end
 
+    class Timeout < Error; end
+
     class ProxyParseError < Error; end
 
     class StubNotFound < Error; end

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -45,7 +45,7 @@ module Excon
         if IO.select([@socket], nil, nil, @connection_params[:read_timeout])
           retry
         else
-          raise(Timeout::Error)
+          raise(Excon::Errors::Timeout.new("read timeout reached"))
         end
       end
       @read_buffer.slice!(0, max_length)
@@ -61,7 +61,7 @@ module Excon
           if IO.select(nil [@socket], nil, @connection_params[:write_timeout])
             retry
           else
-            raise(Timeout::Error)
+            raise(Excon::Errors::Timeout.new("write timeout reached"))
           end
         end
       end


### PR DESCRIPTION
`Timeout::Error` is a descendant of `SignalError` so a plain `rescue` will not catch it. Thus, it won't be caught and retried for idempotent requests.

This patch changes things so `StandardError` and `Timeout::Error` are rescued and retried for idempotent requests.
