### PR TITLE
Allow changing the retry limit.

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -5,6 +5,7 @@ module Excon
     CR_NL     = "\r\n"
     HTTP_1_1  = " HTTP/1.1\r\n"
     FORCE_ENC = CR_NL.respond_to?(:force_encoding)
+    DEFAULT_RETRY_LIMIT = 4
 
     # Initializes a new Connection instance
     #   @param [String] url The destination URL
@@ -198,7 +199,7 @@ module Excon
 
     rescue => request_error
       if params[:idempotent] && [Excon::Errors::SocketError, Excon::Errors::HTTPStatusError].any? {|ex| request_error.kind_of? ex }
-        retries_remaining ||= 4
+        retries_remaining ||= retry_limit
         retries_remaining -= 1
         if retries_remaining > 0
           if params[:body].respond_to?(:pos=)
@@ -224,6 +225,12 @@ module Excon
           request(params.merge!(:method => :#{method}), &block)
         end
       DEF
+    end
+
+    attr_writer :retry_limit
+
+    def retry_limit
+      @retry_limit ||= DEFAULT_RETRY_LIMIT
     end
 
   private

--- a/tests/idempotent_tests.rb
+++ b/tests/idempotent_tests.rb
@@ -10,7 +10,7 @@ Shindo.tests('Excon request idempotencey') do
     run_count = 0
     Excon.stub({:method => :get}) { |params|
       run_count += 1
-      if run_count < 4 # First 3 calls fail.
+      if run_count <= 3 # First 3 calls fail.
         raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
@@ -49,6 +49,74 @@ Shindo.tests('Excon request idempotencey') do
     }
 
     connection = Excon.new('http://127.0.0.1:9292')
+    response = connection.request(:method => :get, :idempotent => true, :path => '/some-path')
+    response.status
+  end
+
+  tests("Lowered retry limit with socket erroring first time").returns(200) do
+    run_count = 0
+    Excon.stub({:method => :get}) { |params|
+      run_count += 1
+      if run_count <= 1 # First call fails.
+        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+      else
+        {:body => params[:body], :headers => params[:headers], :status => 200}
+      end
+    }
+
+    connection = Excon.new('http://127.0.0.1:9292')
+    connection.retry_limit = 2
+    response = connection.request(:method => :get, :idempotent => true, :path => '/some-path')
+    response.status
+  end
+
+  tests("Lowered retry limit with socket erroring first 3 times").raises(Excon::Errors::SocketError) do
+    run_count = 0
+    Excon.stub({:method => :get}) { |params|
+      run_count += 1
+      if run_count <= 3 # First 3 calls fail.
+        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+      else
+        {:body => params[:body], :headers => params[:headers], :status => 200}
+      end
+    }
+
+    connection = Excon.new('http://127.0.0.1:9292')
+    connection.retry_limit = 2
+    response = connection.request(:method => :get, :idempotent => true, :path => '/some-path')
+    response.status
+  end
+
+  tests("Raised retry limit with socket erroring first 5 times").returns(200) do
+    run_count = 0
+    Excon.stub({:method => :get}) { |params|
+      run_count += 1
+      if run_count <= 5 # First 5 calls fail.
+        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+      else
+        {:body => params[:body], :headers => params[:headers], :status => 200}
+      end
+    }
+
+    connection = Excon.new('http://127.0.0.1:9292')
+    connection.retry_limit = 8
+    response = connection.request(:method => :get, :idempotent => true, :path => '/some-path')
+    response.status
+  end
+
+  tests("Raised retry limit with socket erroring first 9 times").raises(Excon::Errors::SocketError) do
+    run_count = 0
+    Excon.stub({:method => :get}) { |params|
+      run_count += 1
+      if run_count <= 9 # First 9 calls fail.
+        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+      else
+        {:body => params[:body], :headers => params[:headers], :status => 200}
+      end
+    }
+
+    connection = Excon.new('http://127.0.0.1:9292')
+    connection.retry_limit = 8
     response = connection.request(:method => :get, :idempotent => true, :path => '/some-path')
     response.status
   end


### PR DESCRIPTION
[Redacted cloud provider] was freaking out the other night and playing with the retry limit in excon required changing the gem.  This update allows the limit to be changed with a simple setter.
