### PR TITLE
Allow changing the retry limit. (redux)

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -11,6 +11,10 @@ module Excon
     HTTP_VERBS = %w{connect delete get head options post put trace}
   end
 
+  unless const_defined?(:DEFAULT_RETRY_LIMIT)
+    DEFAULT_RETRY_LIMIT = 4
+  end
+
   unless ::IO.const_defined?(:WaitReadable)
     class ::IO
       module WaitReadable; end
@@ -22,5 +26,4 @@ module Excon
       module WaitWritable; end
     end
   end
-
 end


### PR DESCRIPTION
[Redacted cloud provider] was freaking out the other night and playing with the retry limit in excon required changing the gem. This update allows the limit to be changed either by passing an argument to the constructor or calling a mutator method after the fact.
