### PR TITLE
dont send Host with Port if its the schemes default

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -69,7 +69,17 @@ module Excon
       # connection has defaults, merge in new params to override
       params = @connection.merge(params)
       params[:headers] = @connection[:headers].merge(params[:headers] || {})
-      params[:headers]['Host'] ||= '' << params[:host] << ':' << params[:port]
+
+      host_scheme = params[:scheme]
+      host_port = params[:port]
+
+      host_header = params[:host]
+
+      unless (host_scheme == "http" and host_port == "80") or (host_scheme == "https" and host_port == "443")
+        host_header = host_header << ':' << host_port
+      end
+
+      params[:headers]['Host'] ||= host_header
 
       # if path is empty or doesn't start with '/', insert one
       unless params[:path][0, 1] == '/'


### PR DESCRIPTION
Apache seems to be picky about that on some Vhost Configs
and will redirect the request from "Host: some.com:80" to
"Host: some.com" which is itself but excon doesnt unterstand it.

So removing the (unneeded :80, :443 ports) makes Apache
happy and doenst break any other Servers.

Not entirely sure if it breaks some Proxy Configs, didnt check with the Http Spec. Also wasnt able to run your tests, not exactly sure which rackups to start.
