### PR TITLE
Avoid ruby warnings

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -23,7 +23,7 @@ module Excon
         :headers           => {},
         :host              => uri.host,
         :instrumentor_name => 'excon',
-        :mock              => Excon.instance_variable_get(:@mock),
+        :mock              => Excon.instance_variable_defined?(:@mock) && Excon.instance_variable_get(:@mock),
         :path              => uri.path,
         :port              => uri.port.to_s,
         :query             => uri.query,
@@ -32,6 +32,8 @@ module Excon
         :scheme            => uri.scheme,
         :write_timeout     => 60
       }.merge!(params)
+
+      @proxy = nil
 
       # use proxy from the environment if present
       if ENV.has_key?('http_proxy')

--- a/tests/idempotent_tests.rb
+++ b/tests/idempotent_tests.rb
@@ -20,7 +20,7 @@ Shindo.tests('Excon request idempotencey') do
       end
     }
 
-    response = @connection.request(:method => :get, :path => '/some-path')
+    @connection.request(:method => :get, :path => '/some-path')
   end
 
   tests("Idempotent request with socket erroring first 3 times").returns(200) do

--- a/tests/stub_tests.rb
+++ b/tests/stub_tests.rb
@@ -2,7 +2,7 @@ Shindo.tests('Excon stubs') do
 
   tests("missing stub").raises(Excon::Errors::StubNotFound) do
     connection = Excon.new('http://127.0.0.1:9292', :mock => true)
-    response = connection.request(:method => :get, :path => '/content-length/100')
+    connection.request(:method => :get, :path => '/content-length/100')
   end
 
   tests("stub({})").raises(ArgumentError) do
@@ -116,7 +116,7 @@ Shindo.tests('Excon stubs') do
 
     test("with block") do
       chunks = []
-      response = connection.request(:method => :get, :path => '/content-length/100') do |chunk, remaining_bytes, total_bytes|
+      connection.request(:method => :get, :path => '/content-length/100') do |chunk, remaining_bytes, total_bytes|
         chunks << chunk
       end
       chunks == ['x' * Excon::CHUNK_SIZE, 'x']


### PR DESCRIPTION
Running with RUBYOPT="-w" helps us find things in the code that can be improved. It would be awesome if all gems made sure that their code is warning free, so we aren't flooded by warnings from third party gems which work great :)

I cleaned the code up slightly just so no warnings are given by excon when I run tests for my own gems that depend on it, or from applications that use it.
