### PR TITLE
Add support to specify ca_file for SSL connections

### DIFF
--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -8,7 +8,7 @@ module Excon
 
       def initialize(socket_error=nil)
         if socket_error.message =~ /certificate verify failed/
-          super('Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs` or `Excon.defaults[:ssl_verify_peer] = false` (less secure).')
+          super('Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs`, `Excon.defaults[:ssl_ca_file] = path_to_file`, or `Excon.defaults[:ssl_verify_peer] = false` (less secure).')
         else
           super(socket_error.message)
         end

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -29,6 +29,8 @@ module Excon
 
         if Excon.defaults[:ssl_ca_path]
           ssl_context.ca_path = Excon.defaults[:ssl_ca_path]
+        elsif Excon.defaults[:ssl_ca_file]
+          ssl_context.ca_file = Excon.defaults[:ssl_ca_file]
         else
           # use default cert store
           store = OpenSSL::X509::Store.new


### PR DESCRIPTION
To allow specifying the full set of options for SSLContext. Also, this change would make it easier to make the Faraday interface for Excon fully consistent, it now only sets the path for certificate files but not for a single file.
