### PR TITLE
rcov is not in bundle, add it.

### DIFF
--- a/excon.gemspec
+++ b/excon.gemspec
@@ -58,6 +58,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('open4')
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
+  s.add_development_dependency('rcov')
   s.add_development_dependency('shindo')
   s.add_development_dependency('sinatra')
 


### PR DESCRIPTION
So that `bundle exec rake coverage` actually works.
