### PR TITLE
Use ENV var to debug/see raw excon requests.

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -36,7 +36,11 @@ module Excon
       elsif params.has_key?(:proxy)
         @proxy = setup_proxy(params[:proxy])
       end
-
+      
+      if ENV['EXCON_DEBUG_REQUESTS']
+        @debug = true
+      end
+      
       if @connection[:scheme] == HTTPS
         # use https_proxy if that has been specified
         if ENV.has_key?('https_proxy')
@@ -196,14 +200,18 @@ module Excon
 
           # write out the request, sans body
           socket.write(request)
+          
+          $stderr.puts(request) if @debug
 
           # write out the body
           if params[:headers]['Content-Length'] != 0
             if params[:body].is_a?(String)
               socket.write(params[:body])
+              $stderr.puts(params[:body]) if @debug
             else
               while chunk = params[:body].read(CHUNK_SIZE)
                 socket.write(chunk)
+                $stderr.puts(chunk) if @debug
               end
             end
           end

--- a/tests/debug_tests.rb
+++ b/tests/debug_tests.rb
@@ -1,0 +1,40 @@
+require "stringio"
+
+Shindo.tests('Test Excon debugging') do
+  
+  def capture_stderr
+    previous_stderr, $stderr = $stderr, StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = previous_stderr
+  end
+  
+  with_rackup('request_methods.ru') do
+      
+    tests("Outputs debug statements to stderr if ENV var is set to debug") do
+      
+      ENV['EXCON_DEBUG_REQUESTS'] = "true"
+      
+      connection = Excon.new('http://localhost:9292')
+      
+      string = "GET / HTTP/1.1\r\nContent-Length: 0\r\nHost: localhost:9292\r\n\r\n"      
+      tests('A mundane get request').returns(string) do        
+        http_request = capture_stderr do         
+          connection.get
+        end
+        http_request
+      end
+
+      string = "POST / HTTP/1.1\r\nContent-Length: 4\r\nHost: localhost:9292\r\n\r\nBODY\n"      
+      tests('A mundane POST request with a body').returns(string) do        
+        http_request = capture_stderr do         
+          connection.post(:body => "BODY")
+        end
+        http_request
+      end
+
+    end
+    
+  end
+end


### PR DESCRIPTION
It would be nice to see the raw request Excon assembles and sends
down the pipe. I wouldn't think there should be a performance hit granted all it's doing
is checking for a EXCON_DEBUG_REQUESTS environment variable.
