### PR TITLE
Content-Length for GET requests with an empty body

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -176,8 +176,9 @@ module Excon
 
           # calculate content length and set to handle non-ascii
           unless params[:headers].has_key?('Content-Length')
-            # GET requests don't usually send bodies
-            unless params[:method].to_s.upcase == "GET" && params[:body].to_s.empty?
+            # The HTTP spec isn't clear on it, but specifically, GET requests don't usually send bodies;
+            # if they don't, sending Content-Length:0 can cause issues.
+            unless (params[:method].to_s.casecmp('GET') == 0 && params[:body].nil?)
               params[:headers]['Content-Length'] = case params[:body]
               when File
                 params[:body].binmode
@@ -207,7 +208,7 @@ module Excon
           socket.write(request)
 
           # write out the body
-          if params[:headers]['Content-Length'] && params[:headers]['Content-Length'] != 0
+          unless params[:body].nil?
             if params[:body].is_a?(String)
               socket.write(params[:body])
             else

--- a/tests/request_method_tests.rb
+++ b/tests/request_method_tests.rb
@@ -30,7 +30,7 @@ Shindo.tests('Excon request methods') do
         connection.post.body
       end
 
-      tests('connetion.delete').returns('DELETE') do
+      tests('connection.delete').returns('DELETE') do
         connection.delete.body
       end
 


### PR DESCRIPTION
...is zero. Even though the HTTP spec doesn't forbid sending a body in a
GET request, it's generally not recommended to send a body via GET. Some
servers behave oddly with a Content-Length of 0 on a GET request since
it seems there are related security vulnerabilities (IIS, I believe)?

The problem I have is basically that Terremark is denying requests because they have a Content-Length: 0 header being passed in GET requests with no body.

This is what they said:

---- 8< ----
We do not expect any content when the client is making a “GET”. Content-length in a GET method is not explicitly prohibited. But message-body (a property which Content-length is based upon) is prohibited in GET requests. So, I would say, do not include Content-Length header for “GET” requests.
---- 8< ----

http://fixunix.com/tcp-ip/66198-http-rfc-related-question-content-length-0-get-request.html

I can provide more detail on how it fails if you need it, but basically I just want to start a discussion here.

Can we just kill the Content-Length:0 for GET requests? It gets set automatically in Excon, and bottom line is I need a way to ensure it doesn't get set.
