### PR TITLE
Fix Tempfile bug

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -147,6 +147,7 @@ module Excon
 
     def detect_content_length(body)
       if body.respond_to?(:binmode)
+        # IO object: File, Tempfile, etc.
         body.binmode
         File.size(body)
       elsif body.is_a?(String)


### PR DESCRIPTION
Since #116 was merged, all requests will fail if Tempfile has not been required or defined:

```
 Excon::Errors::SocketError:
   uninitialized constant Excon::Connection::Tempfile
 # /export/chk/excon/lib/excon/connection.rb:188:in `request_kernel'
 # /export/chk/excon/lib/excon/connection.rb:97:in `request'
```

This fixes the issue with method detection and extracts the content_length detection into it's own method.

I'm not going to apply this myself because I can't get the tests to run cleanly locally right now. Shindo will run a single test file and then stall until I ultimately force it to quit. Anyone else run into this issue?

This should get merged in pretty soon though, as 0.13.1 is effectively broken for any app that doesn't require Tempfile. Btw, I'm thinking one of our dev dependencies uses Tempfile, which is why the failure was masked in our tests.
