### PR TITLE
accept a port as an option

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -56,7 +56,7 @@ module Excon
         @connection[:headers]['Authorization'] ||= "Basic #{auth}"
       end
 
-      @socket_key = '' << @connection[:host] << ':' << @connection[:port]
+      @socket_key = '' << @connection[:host] << ':' << @connection[:port].to_s
       reset
     end
 


### PR DESCRIPTION
Ports passed in with the URL are already handled appropriately, but ports passed as options aren't. This tiny change fixes that.
