### PR TITLE
Fix issue with excon mocking and vcr

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -274,6 +274,15 @@ module Excon
     end
 
     def invoke_stub(params)
+
+      #deal with File/Tempfile body:
+      unless params[:body].nil? or params[:body].is_a?(String)
+       params[:body].binmode if params[:body].respond_to?(:binmode)
+       params[:body].rewind  if params[:body].respond_to?(:rewind)
+       body_string = String.new(params[:body].read)
+       params[:body] = body_string
+      end
+
       params[:captures] = {:headers => {}} # setup data to hold captures
       for stub, response in Excon.stubs
         headers_match = !stub.has_key?(:headers) || stub[:headers].keys.all? do |key|


### PR DESCRIPTION
Hi, latest VCR gem ( as of [2.2.0](https://github.com/myronmarston/vcr/blob/master/CHANGELOG.md#220-may-31-2012) ) has put guards in against non-string body sent in a request.

It looks like excon sends a request body 'as is' when mocking, even if this is a Tempfile. I only came across this due to this recent change/guard in the VCR gem.

Previously the recorded VCR fixtures for a POST would look like:

```
1 --- $
2 http_interactions: $
3 - request: $
4     method: put$
5     uri: https://testbucki2rpux3wdelmegoogel.commondatastorage.googleapis.com/testblobk1ds91kVdelmegoogel$
6     body: $
7       string: "#<File:0xb69fd808>"$   
```
# ...

Now when running my Minitests I get:
# <Excon::Errors::SocketError: VCR::Request initialized with an invalid body:

The attached edit reads the contents of file into a String and assigns that to body. So the recorded VCR fixtures look more like:

```
1 --- $   
2 http_interactions: $
3 - request: $
4     method: put$
5     uri: https://testbucki2rpux3wdelmegoogel.commondatastorage.googleapis.com/testblobk1ds91kVdelmegoogel$
6     body: $
7       string: !binary |$
8         iVBORw0KGgoAAAANSUhEUgAAAmwAAAEJCAYAAAApRHtRAAAAGXRFWHRTb2Z0$
9         d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAXxZJREFUeNrsvQmUJNV57/lF$
10         RG61d1XvTW800NBAswsEAiRsNkugsS2BZDDyom10xnrHSBoLjeeMOF6O0Jsn
```
# ...

I've made a [quick gist](https://gist.github.com/2996416) that you can run to reproduce/demostrate the issue. Running the gist without my patch will produce the 

```
#<Excon::Errors::SocketError: VCR::Request initialized with an invalid body:
```

Many thanks for your time and consideration, 

all the best, marios
