### PR TITLE
Excon.stub will break out items from :url if supplied.

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -103,6 +103,20 @@ module Excon
     #   @param [Hash<Symbol, >] request params to match against, omitted params match all
     #   @param [Hash<Symbol, >] response params to return from matched request or block to call with params
     def stub(request_params, response_params = nil)
+      if url = request_params.delete(:url)
+        uri = URI.parse(url)
+        request_params.update(
+          :host              => uri.host,
+          :path              => uri.path,
+          :port              => uri.port.to_s,
+          :query             => uri.query,
+          :scheme            => uri.scheme
+        )
+        if uri.user || uri.password
+          request_params[:headers] ||= {}
+          request_params[:headers]['Authorization'] ||= 'Basic ' << ['' << uri.user.to_s << ':' << uri.password.to_s].pack('m').delete(Excon::CR_NL)
+        end
+      end
       if block_given?
         if response_params
           raise(ArgumentError.new("stub requires either response_params OR a block"))

--- a/tests/stub_tests.rb
+++ b/tests/stub_tests.rb
@@ -148,6 +148,16 @@ Shindo.tests('Excon stubs') do
 
   Excon.stubs.clear
 
+  tests("stub({:url => 'https://user:pass@foo.bar.com:9999/baz?quux=true'}, {:status => 200})") do
+    Excon.stub({:url => 'https://user:pass@foo.bar.com:9999/baz?quux=true'}, {:status => 200})
+
+    tests("get(:expects => 200)") do
+      Excon.new("https://user:pass@foo.bar.com:9999/baz?quux=true", :mock => true).get(:expects => 200)
+    end
+  end
+
+  Excon.stubs.clear
+
   tests("stub({}, {:status => 404, :body => 'Not Found'}") do
 
     connection = Excon.new('http://127.0.0.1:9292', :mock => true)


### PR DESCRIPTION
Makes precise stubbing with a full URL easier.
