### PR TITLE
Set body file position to 0 before reading

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -108,9 +108,6 @@ module Excon
         retries_remaining ||= params[:retry_limit]
         retries_remaining -= 1
         if retries_remaining > 0
-          if params[:body].respond_to?(:pos=)
-            params[:body].pos = 0
-          end
           retry
         else
           if params.has_key?(:instrumentor)


### PR DESCRIPTION
I noticed an issue with Fog::Storage files.  If you repeatedly saved a fog File object, the underlying body file object would never have its position reset.  

I figured changing Excon would make sense, especially since the error handling reset the file position anyways.  There are a couple other solutions though:
- Set position after reading back to 0
- Set position after reading back to the original position (may not be 0)
- Fix in Fog.  This could be done, but considering Excon already rewinds and sets position, it seems like this is fine.

Let em know your thoughts.
