### PR TITLE
No longer read body in response when CONNECT method

### DIFF
--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -21,6 +21,8 @@ module Excon
 
     class ProxyParseError < Error; end
 
+    class ProxyConnectionError < Error; end
+
     class StubNotFound < Error; end
 
     class HTTPStatusError < Error

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -31,7 +31,7 @@ module Excon
         end
       end
 
-      unless (params[:method].to_s.casecmp('HEAD') == 0) || NO_ENTITY.include?(response.status)
+      unless (['HEAD', 'CONNECT'].include?(params[:method].to_s.upcase) || NO_ENTITY.include?(response.status)
 
         # check to see if expects was set and matched
         expected_status = !params.has_key?(:expects) || [*params[:expects]].include?(response.status)

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -51,7 +51,10 @@ module Excon
         @socket.write(request)
 
         # eat the proxy's connection response
-        Excon::Response.parse(@socket, {})
+        response = Excon::Response.parse(@socket, {:method => "CONNECT"})
+	if response[:status] != 200
+	  raise(Excon::Errors::ProxyConnectionError.new("Proxy connection is not established"))
+	end
       end
 
       # convert Socket to OpenSSL::SSL::SSLSocket


### PR DESCRIPTION
In Excon::Response#parse, if response status has possibility to have body, it is always read. But  the response for CONNECT method has no body. It blocks socket reading. As a result, process is timeout.

To avoid this, this patch does not read any body from response for CONNECT method.
