### PR TITLE
Prevent nonblock mode when run test with specific jRuby version

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -11,7 +11,9 @@ module Excon
     CHUNK_SIZE = DEFAULT_CHUNK_SIZE
   end
 
-  DEFAULT_NONBLOCK = OpenSSL::SSL::SSLSocket.public_method_defined?(:connect_nonblock) &&
+  # jruby 1.9 mode has nonblock method issues until 1.7.0.
+  DEFAULT_NONBLOCK = (!defined?(JRUBY_VERSION) || JRUBY_VERSION > '1.7.0' || VERSION < '1.9') &&
+    OpenSSL::SSL::SSLSocket.public_method_defined?(:connect_nonblock) &&
     OpenSSL::SSL::SSLSocket.public_method_defined?(:read_nonblock) &&
     OpenSSL::SSL::SSLSocket.public_method_defined?(:write_nonblock)
 

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -6,12 +6,8 @@ Bundler.require(:default, :development)
 require 'stringio'
 
 def basic_tests(url = 'http://127.0.0.1:9292')
-  values = [false, true]
-  if defined?(JRUBY_VERSION) && JRUBY_VERSION == '1.7.0' && VERSION > '1.9'
-    values = [false]
-  end
+  [false, true].each do |nonblock|
 
-  values.each do |nonblock|
     connection = Excon.new(url, :nonblock => nonblock, :ssl_verify_peer => false)
 
     tests("nonblock => #{nonblock}") do


### PR DESCRIPTION
JRuby 1.7.0 with 1.9 mode has issue arount syswrite_nonblock.
This patch avoid to run test with nonblock on such JRuby.
