### PR TITLE
Mimic ruby 1.9.3 behaviour when printing a Hash using Hash.inspect

### DIFF
--- a/lib/excon/standard_instrumentor.rb
+++ b/lib/excon/standard_instrumentor.rb
@@ -6,7 +6,7 @@ module Excon
         params[:headers] = params[:headers].dup
         params[:headers]['Authorization'] = REDACTED
       end
-      $stderr.puts("#{name}  #{params}")
+      $stderr.puts("#{name}  #{params.inspect}")
       if block_given?
         yield
       end


### PR DESCRIPTION
This improves instrumentor output readability in ruby 1.8.7 by using
Hash.inspect. From what I've seen, it does not alter behaviour in 1.9.3.
