### PR TITLE
Removed redundant check of @eof in socket.read

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -14,6 +14,9 @@ module Excon
       @read_buffer = ''
       @eof = false
 
+      @params[:family] ||= ::Socket::Constants::AF_UNSPEC
+      @proxy[:family]  ||= ::Socket::Constants::AF_UNSPEC if @proxy
+
       connect
     end
 
@@ -22,9 +25,9 @@ module Excon
       exception = nil
 
       addrinfo = if @proxy
-        ::Socket.getaddrinfo(@proxy[:host], @proxy[:port].to_i, ::Socket::Constants::AF_UNSPEC, ::Socket::Constants::SOCK_STREAM)
+        ::Socket.getaddrinfo(@proxy[:host], @proxy[:port].to_i, @proxy[:family], ::Socket::Constants::SOCK_STREAM)
       else
-        ::Socket.getaddrinfo(@params[:host], @params[:port].to_i, ::Socket::Constants::AF_UNSPEC, ::Socket::Constants::SOCK_STREAM)
+        ::Socket.getaddrinfo(@params[:host], @params[:port].to_i, @params[:family], ::Socket::Constants::SOCK_STREAM)
       end
 
       addrinfo.each do |_, port, _, ip, a_family, s_type|


### PR DESCRIPTION
Method immediate returns nil on EOF; first check for @eof (returning '') should never be possible.
Added ability to pass in the family for getaddrinfo call for both params and proxy, defaulting to unspecified as now.

(Sorry, was supposed to be in two branches.)
