### PR TITLE
Use ruby's built-in resolver to get the host address

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -37,9 +37,11 @@ module Excon
       exception = nil
 
       addrinfo = if @data[:proxy]
-        ::Socket.getaddrinfo(@data[:proxy][:host], @data[:proxy][:port], @data[:proxy][:family], ::Socket::Constants::SOCK_STREAM)
+        host = Resolv.getaddress @data[:proxy][:host]
+        ::Socket.getaddrinfo(host, @data[:proxy][:port], @data[:proxy][:family], ::Socket::Constants::SOCK_STREAM)
       else
-        ::Socket.getaddrinfo(@data[:host], @data[:port], @data[:family], ::Socket::Constants::SOCK_STREAM)
+        host = Resolv.getaddress @data[:host]
+        ::Socket.getaddrinfo(host, @data[:port], @data[:family], ::Socket::Constants::SOCK_STREAM)
       end
 
       addrinfo.each do |_, port, _, ip, a_family, s_type|


### PR DESCRIPTION
Use the built-in Resolv class to get the host address before
passing it to Socket.getaddrinfo.

One of the things you can do with this is to replace the nameserver
the ruby process is using, and set different one, without having
to tweak your system's resolver settings (i.e. /etc/resolv.conf)
or manually resolving every host before passing it to an Excon request

Imaging we want to use a specific nameserver to resolv non public
domain names, available in our company's private nameserver:

```
require 'resolv'
require 'excon'

external_dns = '192.168.1.1'
resolver = Resolv::DNS.new(:nameserver => [external_dns], :ndots => 1)
Resolv::DefaultResolver.instance_variable_set :@resolvers,
                                              [resolver]
Excon.get 'https://myserver.mycompany.lan'
```

Where 'myserver.mycompany.lan' is known only to the DNS server at
192.168.1.1. We could also use resolv-replace.rb from the stdlib
and transparently replace the resolver globally to our process.

We also use this kind of stuff to run tests using different nameservers
transparently, without having to update system's configuration. i.e.:

```
external_dns = ENV['NAMESERVER']
resolver = Resolv::DNS.new(:nameserver => [external_dns], :ndots => 1)
Resolv::DefaultResolver.instance_variable_set :@resolvers,
                                              [resolver]

Tests.run # test code here
```

And then using the env variable before running the tests:

```
$ NAMESERVER=192.168.1.1 rake test
```
