### PR TITLE
Fixed issue with Expects middleware

### DIFF
--- a/lib/excon/middlewares/expects.rb
+++ b/lib/excon/middlewares/expects.rb
@@ -6,7 +6,7 @@ module Excon
           raise(
             Excon::Errors.status_error(
               datum.reject {|key,value| key == :response},
-              datum[:response]
+              Excon::Response.new(datum[:response])              
             )
           )
         else

--- a/tests/middlewares/mock_tests.rb
+++ b/tests/middlewares/mock_tests.rb
@@ -167,6 +167,15 @@ Shindo.tests('Excon stubs') do
       connection.request(:expects => 200, :method => :get, :path => '/')
     end
 
+    tests("Expects exception should contain response object") do
+      begin
+        connection.request(:expects => 200, :method => :get, :path => '/')
+      rescue Excon::Errors::NotFound => e
+        returns(Excon::Response) { e.response.class }
+      end
+    end
+
+
     test("request(:expects => 200, :method => :get, :path => '/') with block does not invoke the block since it raises an error") do
       block_called = false
       begin


### PR DESCRIPTION
fixed bug where generated exceptions contained a hash rather than a Excon::Response object.

Please refer to Fog Google groups for more details.

https://groups.google.com/forum/?fromgroups=#!topic/ruby-fog/cFET-ljnAt8
