### PR TITLE
Raise the error if it occurs before datum[:stack] gets set

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -239,7 +239,11 @@ module Excon
       end
     rescue => error
       datum[:error] = error
-      datum[:stack].error_call(datum)
+      if datum[:stack]
+        datum[:stack].error_call(datum)
+      else
+        raise error
+      end
     end
 
     # Sends the supplied requests to the destination host using pipelining.


### PR DESCRIPTION
This happens say when assert_valid_keys_for_argument! fails.
