### PR TITLE
Standard instrumentor should redact `:password` in params

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -288,6 +288,10 @@ module Excon
         vars[:'@data'][:headers] = vars[:'@data'][:headers].dup
         vars[:'@data'][:headers]['Authorization'] = REDACTED
       end
+      if vars[:'@data'][:password]
+        vars[:'@data'] = vars[:'@data'].dup
+        vars[:'@data'][:password] = REDACTED
+      end
       inspection = '#<Excon::Connection:'
       inspection << (object_id << 1).to_s(16)
       vars.each do |key, value|

--- a/lib/excon/standard_instrumentor.rb
+++ b/lib/excon/standard_instrumentor.rb
@@ -1,10 +1,13 @@
 module Excon
   class StandardInstrumentor
     def self.instrument(name, params = {}, &block)
+      params = params.dup
       if params.has_key?(:headers) && params[:headers].has_key?('Authorization')
-        params = params.dup
         params[:headers] = params[:headers].dup
         params[:headers]['Authorization'] = REDACTED
+      end
+      if params.has_key?(:password)
+        params[:password] = REDACTED
       end
       $stderr.puts("#{name}  #{params.inspect}")
       if block_given?

--- a/tests/authorization_header_tests.rb
+++ b/tests/authorization_header_tests.rb
@@ -7,12 +7,23 @@ with_rackup('basic_auth.ru') do
             ]
     cases.each do |desc,url,auth_header|
       conn = Excon.new(url)
+
       test("authorization header concealed for #{desc}") do
         !conn.inspect.include?(auth_header)
       end
 
       test("authorization header remains correct for #{desc}") do
         conn.data[:headers]['Authorization'] == auth_header
+      end
+
+      if conn.data[:password]
+        test("password param concealed for #{desc}") do
+          !conn.inspect.include?(conn.data[:password])
+        end
+      end
+
+      test("password param remains correct for #{desc}") do
+        conn.data[:password] == URI.parse(url).password
       end
 
     end


### PR DESCRIPTION
Similar to how the `Authorization` header is redacted.
