### PR TITLE
Prevent default middlewares from being mutated

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -40,6 +40,9 @@ module Excon
       # merge does not deep-dup, so make sure headers is not the original
       @data[:headers] = @data[:headers].dup
 
+      # the same goes for :middlewares
+      @data[:middlewares] = @data[:middlewares].dup
+
       @data.merge!(params)
 
       if @data[:scheme] == HTTPS && (ENV.has_key?('https_proxy') || ENV.has_key?('HTTPS_PROXY'))


### PR DESCRIPTION
Hi - ran into a problem where I was accidentally mutating the default middlewares array. To prevent it, I followed the pattern used for the headers hash.

This solved my immediate problem, but I think there could be a better way to add middleware than appending to the `@data[:middlewares]` array of the connection. Maybe connection#use.
