### PR TITLE
Alternative no_proxy support

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -55,8 +55,8 @@ module Excon
       @data.merge!(params)
 
       no_proxy_env = ENV["no_proxy"] || ENV["NO_PROXY"] || ""
-      no_proxy_list = no_proxy_env.scan(/(?:[^\s,:]+)(?::\d+)?/).map { |s| s[0] == '.' ? s[1..-1] : s }
-      if not no_proxy_list.index { |h| /(^|\.)#{h}$/.match(@data[:host]) }
+      no_proxy_list = no_proxy_env.scan(/\*?\.?([^\s,:]+)(?::(\d+))?/i).map { |s| [s[0], s[1]] }
+      unless no_proxy_list.index { |h| /(^|\.)#{h[0]}$/.match(@data[:host]) && (h[1].nil? || h[1].to_i == @data[:port]) }
         if @data[:scheme] == HTTPS && (ENV.has_key?('https_proxy') || ENV.has_key?('HTTPS_PROXY'))
           @data[:proxy] = setup_proxy(ENV['https_proxy'] || ENV['HTTPS_PROXY'])
         elsif (ENV.has_key?('http_proxy') || ENV.has_key?('HTTP_PROXY'))

--- a/tests/header_tests.rb
+++ b/tests/header_tests.rb
@@ -1,4 +1,5 @@
 Shindo.tests('Excon response header support') do
+  cleanEnv
 
   with_rackup('response_header.ru') do
 
@@ -45,5 +46,7 @@ Shindo.tests('Excon response header support') do
     end
 
   end
+  
+  restoreEnv
 
 end

--- a/tests/middlewares/mock_tests.rb
+++ b/tests/middlewares/mock_tests.rb
@@ -1,4 +1,5 @@
 Shindo.tests('Excon stubs') do
+  cleanEnv
 
   tests("missing stub").raises(Excon::Errors::StubNotFound) do
     connection = Excon.new('http://127.0.0.1:9292', :mock => true)
@@ -198,4 +199,5 @@ Shindo.tests('Excon stubs') do
     end
   end
 
+  restoreEnv
 end

--- a/tests/proxy_tests.rb
+++ b/tests/proxy_tests.rb
@@ -1,12 +1,9 @@
 Shindo.tests('Excon proxy support') do
+  cleanEnv
 
   tests('proxy configuration') do
 
     tests('no proxy') do
-      ENV.delete('http_proxy')
-      ENV.delete('https_proxy')
-      ENV.delete('HTTP_PROXY')
-      ENV.delete('HTTPS_PROXY')
       connection = Excon.new('http://foo.com')
 
       tests('connection.data[:proxy]').returns(nil) do
@@ -30,10 +27,8 @@ Shindo.tests('Excon proxy support') do
       end
     end
 
-    tests('with lowercase proxy config from the environment') do
-      ENV['http_proxy'] = 'http://myproxy:8080'
-      ENV['https_proxy'] = 'http://mysecureproxy:8081'
-      ENV['no_proxy'] = 'noproxy, subdomain.noproxy2'
+    def proxyEnv(env)
+      setupEnv(env)
 
       tests('an http connection') do
         connection = Excon.new('http://foo.com')
@@ -41,7 +36,7 @@ Shindo.tests('Excon proxy support') do
         tests('connection.data[:proxy][:host]').returns('myproxy') do
           connection.data[:proxy][:host]
         end
-        
+
         tests('connection.data[:proxy][:port]').returns('8080') do
           connection.data[:proxy][:port]
         end
@@ -96,73 +91,31 @@ Shindo.tests('Excon proxy support') do
       end
 
       tests('an http connection with subdomain in no_proxy') do
-        connection = Excon.new('http://unproxied.noproxy2')
+        connection = Excon.new('http://a.subdomain.noproxy2')
 
         tests('connection.data[:proxy]').returns(nil) do
-          nil
+          connection.data[:proxy]
         end
       end
-
-      ENV.delete('http_proxy')
-      ENV.delete('https_proxy')
-      ENV.delete('no_proxy')
+      
+      restoreEnv
     end
 
-    tests('with uppercase proxy config from the environment') do
-      ENV['HTTP_PROXY'] = 'http://myproxy:8080'
-      ENV['HTTPS_PROXY'] = 'http://mysecureproxy:8081'
-
-      tests('an http connection') do
-        connection = Excon.new('http://foo.com')
-
-        tests('connection.data[:proxy][:host]').returns('myproxy') do
-          connection.data[:proxy][:host]
-        end
-
-        tests('connection.data[:proxy][:port]').returns('8080') do
-          connection.data[:proxy][:port]
-        end
-
-        tests('connection.data[:proxy][:scheme]').returns('http') do
-          connection.data[:proxy][:scheme]
-        end
+    tests('with complete proxy config from the environment') do
+      env = {'http_proxy' => 'http://myproxy:8080',
+              'https_proxy' => 'http://mysecureproxy:8081',
+              'no_proxy' => 'noproxy, subdomain.noproxy2'}
+      
+      tests('lowercase') { proxyEnv(env) }
+      upperenv = {}
+      env.each do |k, v|
+        upperenv[k.upcase] = v
       end
-
-      tests('an https connection') do
-        connection = Excon.new('https://secret.com')
-
-        tests('connection.data[:proxy][:host]').returns('mysecureproxy') do
-          connection.data[:proxy][:host]
-        end
-
-        tests('connection.data[:proxy][:port]').returns('8081') do
-          connection.data[:proxy][:port]
-        end
-
-        tests('connection.data[:proxy][:scheme]').returns('http') do
-          connection.data[:proxy][:scheme]
-        end
-      end
-
-      tests('http proxy from the environment overrides config') do
-        connection = Excon.new('http://foo.com', :proxy => 'http://hard.coded.proxy:6666')
-
-        tests('connection.data[:proxy][:host]').returns('myproxy') do
-          connection.data[:proxy][:host]
-        end
-
-        tests('connection.data[:proxy][:port]').returns('8080') do
-          connection.data[:proxy][:port]
-        end
-      end
-
-      ENV.delete('HTTP_PROXY')
-      ENV.delete('HTTPS_PROXY')
+      tests('uppercase') { proxyEnv(upperenv) }
     end
 
     tests('with only http_proxy config from the environment') do
-      ENV['http_proxy'] = 'http://myproxy:8080'
-      ENV.delete('https_proxy')
+      setupEnv({'http_proxy' => 'http://myproxy:8080' })
 
       tests('an https connection') do
         connection = Excon.new('https://secret.com')
@@ -180,7 +133,7 @@ Shindo.tests('Excon proxy support') do
         end
       end
 
-      ENV.delete('http_proxy')
+      restoreEnv
     end
 
   end
@@ -240,5 +193,7 @@ Shindo.tests('Excon proxy support') do
     end
 
   end
+  
+  restoreEnv
 
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -140,6 +140,36 @@ def basic_tests(url = 'http://127.0.0.1:9292', options = {})
   end
 end
 
+
+@@proxy_environment_variables = ['http_proxy', 'https_proxy', 'no_proxy'] # All lower-case
+@@saved_environment_stack = []
+
+def cleanEnv
+  current = {}
+  def moveEnv(store, k)
+    store[k] = ENV[k]
+    ENV.delete(k)
+  end
+  
+  @@proxy_environment_variables.each do |k|
+    moveEnv current, k
+    moveEnv current, k.upcase
+  end
+  @@saved_environment_stack << current
+end
+
+def setupEnv(env)
+  cleanEnv
+  env.each do |k, v|
+    ENV[k] = v
+  end
+end
+
+
+def restoreEnv
+  ENV.update(@@saved_environment_stack.pop)
+end
+
 def rackup_path(*parts)
   File.expand_path(File.join(File.dirname(__FILE__), 'rackups', *parts))
 end


### PR DESCRIPTION
I also need the no_proxy support, and didn't realised, there is already another pull-request
and wrote one up myself.

Of course, feel free to drop this.

But I want to emphasise the need of no_proxy support in a large scale corporate environment, which runs all external traffic through a proxy, but cannot afford to run all traffic through it.
