### PR TITLE
handle problems with default ports and redirects

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -106,7 +106,7 @@ module Excon
           # start with "METHOD /path"
           request = datum[:method].to_s.upcase << ' '
           if @data[:proxy]
-            request << datum[:scheme] << '://' << @data[:host] << ':' << @data[:port].to_s
+            request << datum[:scheme] << '://' << @data[:host] << port_string(data[:port], data[:scheme])
           end
           request << datum[:path]
 
@@ -215,7 +215,7 @@ module Excon
       datum = @data.merge(params)
       invalid_keys_warning(params, VALID_CONNECTION_KEYS)
       datum[:headers] = @data[:headers].merge(datum[:headers] || {})
-      datum[:headers]['Host']   ||= '' << datum[:host] << ':' << datum[:port].to_s
+      datum[:headers]['Host']   ||= '' << datum[:host] << port_string(datum[:port], datum[:scheme])
       datum[:retries_remaining] ||= datum[:retry_limit]
 
       # if path is empty or doesn't start with '/', insert one
@@ -385,5 +385,17 @@ module Excon
       end
     end
 
+    def port_string(port=80, scheme="http")
+      scheme = scheme.to_s.downcase
+      port = port.to_i
+
+      if port == 80 && scheme == "http"
+        ""
+      elsif port == 443 && scheme == "https"
+        ""
+      else
+        ":#{port}"
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi,

This is a problem encountered by every HTTP library and most of them address this. I wasn't sure how best to write a test for it for you, so direction would be helpful.

The issue is that Apache + Wordpress, when issuing redirects, treat `Host: hostname.com:80` as different from `Host: hostname.com`. This means that in almost all cases, it is safer to drop the `:80` from the `Host:` header in HTTP requests and the `:443` from HTTPS requests.
