### PR TITLE
Add before_retry_block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Both one-off and persistent connections support many other options. Here are a f
     # this request can be repeated safely, retry up to 6 times
     connection.request(:idempotent => true, :retry_limit => 6)
 
+    # call a block before each retry
+    connection.request(:idempotent => true, :before_retry_block => proc {|params| ... })
+
     # opt-out of nonblocking operations for performance and/or as a workaround
     connection.request(:nonblock => false)
 

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -30,6 +30,7 @@ module Excon
   REDACTED = 'REDACTED'
 
   VALID_CONNECTION_KEYS = [
+    :before_retry_block,
     :body,
     :captures,
     :chunk_size,

--- a/lib/excon/middlewares/idempotent.rb
+++ b/lib/excon/middlewares/idempotent.rb
@@ -9,6 +9,9 @@ module Excon
           datum[:connection].reset
           datum.delete(:response)
           datum.delete(:error)
+          if datum[:before_retry_block]
+            datum[:before_retry_block].call(datum)
+          end
           datum[:connection].request(datum)
         else
           @stack.error_call(datum)


### PR DESCRIPTION
I've been wanting something like `:retry_delay` to sleep between retries but thought `:before_retry_block` would be more general.

Looking for feedback.
