### PR TITLE
Respect Ruby's verbosity conventions

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -63,9 +63,14 @@ require 'excon/standard_instrumentor'
 module Excon
   class << self
 
+    def display_warning(warning)
+      # Ruby convention mandates complete silence when VERBOSE == nil
+      $stderr.puts(warning) if !ENV['VERBOSE'].nil?
+    end
+
     # Status of mocking
     def mock
-      $stderr.puts("Excon#mock is deprecated, pass Excon.defaults[:mock] instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      display_warning("Excon#mock is deprecated, pass Excon.defaults[:mock] instead (#{caller.first}")
       self.defaults[:mock]
     end
 
@@ -73,33 +78,33 @@ module Excon
     # false is the default and works as expected
     # true returns a value from stubs or raises
     def mock=(new_mock)
-      $stderr.puts("Excon#mock is deprecated, pass Excon.defaults[:mock]= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      display_warning("Excon#mock is deprecated, pass Excon.defaults[:mock]= instead (#{caller.first})")
       self.defaults[:mock] = new_mock
     end
 
     # @return [String] The filesystem path to the SSL Certificate Authority
     def ssl_ca_path
-      $stderr.puts("Excon#ssl_ca_path is deprecated, use Excon.defaults[:ssl_ca_path] instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      display_warning("Excon#ssl_ca_path is deprecated, use Excon.defaults[:ssl_ca_path] instead (#{caller.first})")
       self.defaults[:ssl_ca_path]
     end
 
     # Change path to the SSL Certificate Authority
     # @return [String] The filesystem path to the SSL Certificate Authority
     def ssl_ca_path=(new_ssl_ca_path)
-      $stderr.puts("Excon#ssl_ca_path= is deprecated, use Excon.defaults[:ssl_ca_path]= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      display_warning("Excon#ssl_ca_path= is deprecated, use Excon.defaults[:ssl_ca_path]= instead (#{caller.first})")
       self.defaults[:ssl_ca_path] = new_ssl_ca_path
     end
 
     # @return [true, false] Whether or not to verify the peer's SSL certificate / chain
     def ssl_verify_peer
-      $stderr.puts("Excon#ssl_verify_peer= is deprecated, use Excon.defaults[:ssl_verify_peer]= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      display_warning("Excon#ssl_verify_peer= is deprecated, use Excon.defaults[:ssl_verify_peer]= instead (#{caller.first})")
       self.defaults[:ssl_verify_peer]
     end
 
     # Change the status of ssl peer verification
     # @see Excon#ssl_verify_peer (attr_reader)
     def ssl_verify_peer=(new_ssl_verify_peer)
-      $stderr.puts("Excon#ssl_verify_peer is deprecated, use Excon.defaults[:ssl_verify_peer] instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      display_warning("Excon#ssl_verify_peer is deprecated, use Excon.defaults[:ssl_verify_peer] instead (#{caller.first})")
       self.defaults[:ssl_verify_peer] = new_ssl_verify_peer
     end
 

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -4,29 +4,29 @@ module Excon
     attr_reader :data
 
     def connection
-      $stderr.puts("Excon::Connection#connection is deprecated use Excon::Connection#data instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Connection#connection is deprecated use Excon::Connection#data instead (#{caller.first})")
       @data
     end
     def connection=(new_params)
-      $stderr.puts("Excon::Connection#connection= is deprecated use Excon::Connection#data= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Connection#connection= is deprecated use Excon::Connection#data= instead (#{caller.first})")
       @data = new_params
     end
 
     def params
-      $stderr.puts("Excon::Connection#params is deprecated use Excon::Connection#data instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      display_waring("Excon::Connection#params is deprecated use Excon::Connection#data instead (#{caller.first})")
       @data
     end
     def params=(new_params)
-      $stderr.puts("Excon::Connection#params= is deprecated use Excon::Connection#data= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Connection#params= is deprecated use Excon::Connection#data= instead (#{caller.first})")
       @data = new_params
     end
 
     def proxy
-      $stderr.puts("Excon::Connection#proxy is deprecated use Excon::Connection#data[:proxy] instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Connection#proxy is deprecated use Excon::Connection#data[:proxy] instead (#{caller.first})")
       @data[:proxy]
     end
     def proxy=(new_proxy)
-      $stderr.puts("Excon::Connection#proxy= is deprecated use Excon::Connection#data[:proxy]= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Connection#proxy= is deprecated use Excon::Connection#data[:proxy]= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
       @data[:proxy] = new_proxy
     end
 
@@ -224,7 +224,7 @@ module Excon
       end
 
       if block_given?
-        $stderr.puts("Excon requests with a block are deprecated, pass :response_block instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+        Excon.display_warning("Excon requests with a block are deprecated, pass :response_block instead (#{caller.first})")
         datum[:response_block] = Proc.new
       end
 
@@ -281,12 +281,12 @@ module Excon
     end
 
     def retry_limit=(new_retry_limit)
-      $stderr.puts("Excon::Connection#retry_limit= is deprecated, pass :retry_limit to the initializer (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Connection#retry_limit= is deprecated, pass :retry_limit to the initializer (#{caller.first})")
       @data[:retry_limit] = new_retry_limit
     end
 
     def retry_limit
-      $stderr.puts("Excon::Connection#retry_limit is deprecated, pass :retry_limit to the initializer (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Connection#retry_limit is deprecated, pass :retry_limit to the initializer (#{caller.first})")
       @data[:retry_limit] ||= DEFAULT_RETRY_LIMIT
     end
 
@@ -335,7 +335,7 @@ module Excon
     def invalid_keys_warning(argument, valid_keys)
       invalid_keys = argument.keys - valid_keys
       unless invalid_keys.empty?
-        $stderr.puts("The following keys are invalid: #{invalid_keys.map(&:inspect).join(', ')}") if !ENV['VERBOSE'].nil?
+        Excon.display_warning("The following keys are invalid: #{invalid_keys.map(&:inspect).join(', ')}")
       end
     end
 

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -106,7 +106,7 @@ module Excon
     end
 
     def params
-      $stderr.puts("Excon::Response#params is deprecated use Excon::Response#data instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Response#params is deprecated use Excon::Response#data instead (#{caller.first})")
       data
     end
 

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -6,11 +6,11 @@ module Excon
     attr_accessor :data
 
     def params
-      $stderr.puts("Excon::Socket#params is deprecated use Excon::Socket#data instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Socket#params is deprecated use Excon::Socket#data instead (#{caller.first})")
       @data
     end
     def params=(new_params)
-      $stderr.puts("Excon::Socket#params= is deprecated use Excon::Socket#data= instead (#{caller.first})") if !ENV['VERBOSE'].nil?
+      Excon.display_warning("Excon::Socket#params= is deprecated use Excon::Socket#data= instead (#{caller.first})")
       @data = new_params
     end
 

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -82,7 +82,7 @@ module Excon
     def check_nonblock_support
       # backwards compatability for things lacking nonblock
       if !DEFAULT_NONBLOCK && @data[:nonblock]
-        $stderr.puts("Excon nonblock is not supported by your OpenSSL::SSL::SSLSocket") if !ENV['VERBOSE'].nil?
+        Excon.display_warning("Excon nonblock is not supported by your OpenSSL::SSL::SSLSocket")
         @data[:nonblock] = false
       end
     end


### PR DESCRIPTION
By Ruby convention, when `ENV['VERBOSE'] == nil`, code should be silent. The default is for `ENV['VERBOSE']` is `false`, which means that for a normal run this branch will still properly show deprecation warnings. There is a really good article on this whole [verbosity issue here](http://mislav.uniqpath.com/2011/06/ruby-verbose-mode/).

As described in #205, I'm using Webmock and am getting output during my test suite run from Excon that I can't control without extreme measures like redefining `$stderr`.

Thoughts?
