### PR TITLE
Add option to set TCP_NODELAY on underlying socket

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -64,6 +64,7 @@ module Excon
     :retries_remaining,
     :retry_limit,
     :scheme,
+    :tcp_nodelay,
     :uri_parser,
     :user,
     :ssl_ca_file,

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -198,6 +198,12 @@ module Excon
         # this will be our last encountered exception
         raise exception
       end
+
+      if @data[:tcp_nodelay]
+        @socket.setsockopt(::Socket::IPPROTO_TCP,
+                           ::Socket::TCP_NODELAY,
+                           true)
+      end
     end
 
   end

--- a/tests/requests_tests.rb
+++ b/tests/requests_tests.rb
@@ -28,4 +28,19 @@ with_rackup('basic.ru') do
     end
 
   end
+
+  Shindo.tests('requests should succeed with tcp_nodelay') do
+
+    connection = Excon.new('http://127.0.0.1:9292', :tcp_nodelay => true)
+
+    tests('GET /content-length/100') do
+      responses = connection.requests([
+        {:method => :get, :path => '/content-length/100'}
+      ])
+
+      tests('get content length is 100').returns('100') do
+        responses.last.headers['Content-Length']
+      end
+    end
+  end
 end


### PR DESCRIPTION
This can improve the performance of persistent connections in low-latency environments. It's particularly useful when the request sizes are small.

I wasn't sure if/where this should be documented.
