### PR TITLE
Pass in client side certs and keys in pem format

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -8,6 +8,7 @@ require 'rbconfig'
 require 'socket'
 require 'timeout'
 require 'uri'
+require 'tempfile'
 
 # Define defaults first so they will be available to other files
 module Excon

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -52,7 +52,7 @@ with_rackup('ssl.ru') do
 end
 
 with_rackup('ssl_verify_peer.ru') do
-  Shindo.tests('Excon basics (ssl)',['focus']) do
+  Shindo.tests('Excon basics (ssl file)',['focus']) do
     connection = Excon::Connection.new({
       :host             => '127.0.0.1',
       :nonblock         => false,
@@ -68,6 +68,22 @@ with_rackup('ssl_verify_peer.ru') do
     basic_tests('https://127.0.0.1:8443',
                 :client_key => File.join(File.dirname(__FILE__), 'data', 'excon.cert.key'),
                 :client_cert => File.join(File.dirname(__FILE__), 'data', 'excon.cert.crt')
+               )
+
+  end
+
+  Shindo.tests('Excon basics (ssl string)', ['focus']) do
+    connection = Excon::Connection.new({
+      :host             => '127.0.0.1',
+      :nonblock         => false,
+      :port             => 8443,
+      :scheme           => 'https',
+      :ssl_verify_peer  => false
+    })
+
+    basic_tests('https://127.0.0.1:8443',
+                :client_key => File.read(File.join(File.dirname(__FILE__), 'data', 'excon.cert.key')),
+                :client_cert => File.read(File.join(File.dirname(__FILE__), 'data', 'excon.cert.crt'))
                )
   end
 end


### PR DESCRIPTION
The client side certs and their associated private keys can currently only be read in as a file path.  Added support for passing it in as a PEM encoded string.  To prevent the private key from being read out of memory, this data is then dumped into a Tempfile and then read back out, similar to the way it is done currently.  Also added tests to ensure this works properly.
