### PR TITLE
Excon::Errors::SocketError out of range char (Java::OrgJcodingsException::EncodingException)

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -129,7 +129,7 @@ module Excon
       params = {
         :host       => uri.host,
         :path       => uri.path,
-        :port       => uri.port,
+        :port       => uri.port.to_s,
         :query      => uri.query,
         :scheme     => uri.scheme,
         :user       => (URI.decode(uri.user) if uri.user),
@@ -150,7 +150,7 @@ module Excon
         request_params.update(
           :host              => uri.host,
           :path              => uri.path,
-          :port              => uri.port,
+          :port              => uri.port.to_s,
           :query             => uri.query,
           :scheme            => uri.scheme
         )

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -380,7 +380,7 @@ module Excon
         {
           :host       => uri.host,
           :password   => uri.password,
-          :port       => uri.port,
+          :port       => uri.port.to_s,
           :scheme     => uri.scheme,
           :user       => uri.user
         }

--- a/tests/middlewares/mock_tests.rb
+++ b/tests/middlewares/mock_tests.rb
@@ -152,9 +152,8 @@ Shindo.tests('Excon stubs') do
   tests("stub({:url => 'https://user:pass@foo.bar.com:9999/baz?quux=true'}, {:status => 200})") do
     Excon.stub({:url => 'https://user:pass@foo.bar.com:9999/baz?quux=true'}, {:status => 200})
 
-    test("get(:expects => 200)") do
-      resp = Excon.new("https://user:pass@foo.bar.com:9999/baz?quux=true", :mock => true).get(:expects => 200)
-      resp.status == 200
+    tests("get(:expects => 200)") do
+      Excon.new("https://user:pass@foo.bar.com:9999/baz?quux=true", :mock => true).get(:expects => 200)
     end
   end
 

--- a/tests/proxy_tests.rb
+++ b/tests/proxy_tests.rb
@@ -18,7 +18,7 @@ Shindo.tests('Excon proxy support') do
         connection.data[:proxy][:host]
       end
 
-      tests('connection.data[:proxy][:port]').returns(8080) do
+      tests('connection.data[:proxy][:port]').returns('8080') do
         connection.data[:proxy][:port]
       end
 
@@ -37,7 +37,7 @@ Shindo.tests('Excon proxy support') do
           connection.data[:proxy][:host]
         end
 
-        tests('connection.data[:proxy][:port]').returns(8080) do
+        tests('connection.data[:proxy][:port]').returns('8080') do
           connection.data[:proxy][:port]
         end
 
@@ -53,7 +53,7 @@ Shindo.tests('Excon proxy support') do
           connection.data[:proxy][:host]
         end
 
-        tests('connection.data[:proxy][:port]').returns(8081) do
+        tests('connection.data[:proxy][:port]').returns('8081') do
           connection.data[:proxy][:port]
         end
 
@@ -69,7 +69,7 @@ Shindo.tests('Excon proxy support') do
           connection.data[:proxy][:host]
         end
 
-        tests('connection.data[:proxy][:port]').returns(8080) do
+        tests('connection.data[:proxy][:port]').returns('8080') do
           connection.data[:proxy][:port]
         end
       end
@@ -125,7 +125,7 @@ Shindo.tests('Excon proxy support') do
           connection.data[:proxy][:host]
         end
 
-        tests('connection.data[:proxy][:port]').returns(8080) do
+        tests('connection.data[:proxy][:port]').returns('8080') do
           connection.data[:proxy][:port]
         end
 


### PR DESCRIPTION
using fog with latest excon on jruby warbled jars I'm getting this error

I tracked the error back to 85add5ac4a30c3b1fab47d04252ed5237a8c0e8c, no idea why that would fail, but after reverting that commit it all goes back to normal

```
Excon::Errors::SocketError out of range char (Java::OrgJcodingsException::EncodingException) at
org.jcodings.SingleByteEncoding.codeToMbc(SingleByteEncoding.java:91)
org.jruby.RubyString.concatNumeric(RubyString.java:2643)
org.jruby.RubyString.concat19(RubyString.java:2628)
org.jruby.RubyString$INVOKER$i$1$0$concat19.call(RubyString$INVOKER$i$1$0$concat19.gen)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.runtime.callsite.ShiftLeftCallSite.call(ShiftLeftCallSite.java:24)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.LocalAsgnNode.interpret(LocalAsgnNode.java:123)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.IfNode.interpret(IfNode.java:116)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:204)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:194)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:336)
org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:179)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:183)
org.jruby.RubyClass.newInstance(RubyClass.java:855)
org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroOrOneOrNBlock.call(JavaMethod.java:294)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.IfNode.interpret(IfNode.java:116)
org.jruby.ast.OpElementOneArgOrAsgnNode.interpret(OpElementOneArgOrAsgnNode.java:68)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:139)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:170)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:306)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:136)
org.jruby.ast.VCallNode.interpret(VCallNode.java:88)
org.jruby.ast.AttrAssignOneArgNode.interpret(AttrAssignOneArgNode.java:32)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.IfNode.interpret(IfNode.java:118)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.RescueNode.executeBody(RescueNode.java:222)
org.jruby.ast.RescueNode.interpret(RescueNode.java:117)
org.jruby.ast.BeginNode.interpret(BeginNode.java:83)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.IfNode.interpret(IfNode.java:118)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.LocalAsgnNode.interpret(LocalAsgnNode.java:123)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.RescueNode.executeBody(RescueNode.java:222)
org.jruby.ast.RescueNode.interpret(RescueNode.java:117)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:204)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:194)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:336)
org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:179)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:183)
org.jruby.ast.CallOneArgBlockPassNode.interpret(CallOneArgBlockPassNode.java:60)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:61)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.FCallOneArgNode.interpret(FCallOneArgNode.java:36)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.IfNode.interpret(IfNode.java:118)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.LocalAsgnNode.interpret(LocalAsgnNode.java:123)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:225)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:202)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:346)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:204)
org.jruby.ast.CallTwoArgNode.interpret(CallTwoArgNode.java:59)
org.jruby.ast.LocalAsgnNode.interpret(LocalAsgnNode.java:123)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:204)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:194)
org.jruby.RubyClass.finvoke(RubyClass.java:618)
org.jruby.RubyBasicObject.send19(RubyBasicObject.java:1709)
org.jruby.RubyKernel.send19(RubyKernel.java:2213)
org.jruby.RubyKernel$INVOKER$s$send19.call(RubyKernel$INVOKER$s$send19.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrTwoOrNBlock.call(JavaMethod.java:364)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:346)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:204)
org.jruby.ast.CallTwoArgNode.interpret(CallTwoArgNode.java:59)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:204)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:194)
org.jruby.runtime.callsite.SuperCallSite.cacheAndCall(SuperCallSite.java:366)
org.jruby.runtime.callsite.SuperCallSite.callBlock(SuperCallSite.java:192)
org.jruby.runtime.callsite.SuperCallSite.call(SuperCallSite.java:197)
org.jruby.runtime.callsite.SuperCallSite.callVarargs(SuperCallSite.java:108)
org.jruby.ast.SuperNode.interpret(SuperNode.java:115)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:139)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:170)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:306)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:136)
org.jruby.ast.VCallNode.interpret(VCallNode.java:88)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:204)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:194)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:336)
org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:179)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:183)
org.jruby.RubyClass.newInstance(RubyClass.java:855)
org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroOrOneOrNBlock.call(JavaMethod.java:294)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.IfNode.interpret(IfNode.java:118)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.IfNode.interpret(IfNode.java:116)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.WhenOneArgNode.when(WhenOneArgNode.java:49)
org.jruby.ast.CaseNode.interpret(CaseNode.java:132)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:139)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:170)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:306)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:136)
org.jruby.ast.VCallNode.interpret(VCallNode.java:88)
org.jruby.ast.LocalAsgnNode.interpret(LocalAsgnNode.java:123)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.RescueNode.executeBody(RescueNode.java:222)
org.jruby.ast.RescueNode.interpret(RescueNode.java:117)
org.jruby.ast.BeginNode.interpret(BeginNode.java:83)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:161)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:178)
org.jruby.RubyClass.finvoke(RubyClass.java:578)
org.jruby.RubyBasicObject.send19(RubyBasicObject.java:1703)
org.jruby.RubyKernel.send19(RubyKernel.java:2209)
org.jruby.RubyKernel$INVOKER$s$send19.call(RubyKernel$INVOKER$s$send19.gen)
org.jruby.internal.runtime.methods.JavaMethod$JavaMethodOneOrNBlock.call(JavaMethod.java:347)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
org.jruby.ast.FCallOneArgNode.interpret(FCallOneArgNode.java:36)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.RescueNode.executeBody(RescueNode.java:222)
org.jruby.ast.RescueNode.interpret(RescueNode.java:117)
org.jruby.ast.EnsureNode.interpret(EnsureNode.java:96)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:225)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:202)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:346)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:204)
org.jruby.ast.CallTwoArgNode.interpret(CallTwoArgNode.java:59)
org.jruby.ast.LocalAsgnNode.interpret(LocalAsgnNode.java:123)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.IfNode.interpret(IfNode.java:116)
org.jruby.ast.IfNode.interpret(IfNode.java:118)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.RescueNode.executeBody(RescueNode.java:222)
org.jruby.ast.RescueNode.interpret(RescueNode.java:117)
org.jruby.ast.BeginNode.interpret(BeginNode.java:83)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:268)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:218)
org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:366)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:238)
org.jruby.ast.CallThreeArgNode.interpret(CallThreeArgNode.java:61)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.IfNode.interpret(IfNode.java:118)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.RescueNode.executeBody(RescueNode.java:222)
org.jruby.ast.RescueNode.interpret(RescueNode.java:117)
org.jruby.ast.BeginNode.interpret(BeginNode.java:83)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:74)
org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:186)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:168)
org.jruby.ast.FCallOneArgNode.interpret(FCallOneArgNode.java:36)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:206)
org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:194)
org.jruby.runtime.Interpreted19Block.call(Interpreted19Block.java:125)
org.jruby.runtime.Block.call(Block.java:101)
org.jruby.RubyProc.call(RubyProc.java:274)
org.jruby.RubyProc.call19(RubyProc.java:255)
org.jruby.RubyProc$INVOKER$i$0$0$call19.call(RubyProc$INVOKER$i$0$0$call19.gen)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:201)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
org.jruby.ast.CallNoArgNode.interpret(CallNoArgNode.java:60)
org.jruby.ast.DAsgnNode.interpret(DAsgnNode.java:110)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.ast.WhileNode.interpret(WhileNode.java:131)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:206)
org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:194)
org.jruby.runtime.Interpreted19Block.call(Interpreted19Block.java:125)
org.jruby.runtime.Block.call(Block.java:101)
org.jruby.RubyProc.call(RubyProc.java:274)
org.jruby.RubyProc.call19(RubyProc.java:255)
org.jruby.RubyProc$INVOKER$i$0$0$call19.call(RubyProc$INVOKER$i$0$0$call19.gen)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:201)
org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:197)
org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
org.jruby.ast.CallSpecialArgNode.interpret(CallSpecialArgNode.java:65)
org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:206)
org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:194)
org.jruby.runtime.Interpreted19Block.call(Interpreted19Block.java:125)
org.jruby.runtime.Block.call(Block.java:101)
org.jruby.RubyProc.call(RubyProc.java:274)
org.jruby.RubyProc.call(RubyProc.java:215)
org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:100)
java.lang.Thread.run(Thread.java:679)
```
