### PR TITLE
excon should have clearer messages for unusable URIs

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -131,6 +131,7 @@ module Excon
     def new(url, params = {})
       uri_parser = params[:uri_parser] || Excon.defaults[:uri_parser]
       uri = uri_parser.parse(url)
+      raise ArgumentError.new("Invalid URI: #{uri}") unless uri.scheme
       params = {
         :host       => uri.host,
         :path       => uri.path,

--- a/tests/errors_tests.rb
+++ b/tests/errors_tests.rb
@@ -1,5 +1,14 @@
 Shindo.tests('HTTPStatusError request/response debugging') do
 
+  tests('new raises errors for bad URIs').returns(true) do
+    begin
+      Excon.new('foo')
+      false
+    rescue => err
+      err.to_s.include? 'foo'
+    end
+  end
+
   with_server('error') do
 
     tests('message does not include response or response info').returns(true) do


### PR DESCRIPTION
URI.parse is very lenient.  It will parse even parse a string with no URI scheme.  If you give a URI like this to Excon, you get a pretty cryptic error message, like:

```
can't convert nil into String (TypeError)
      /Users/Thoughtworker/repos/rackspace/excon/lib/excon/connection.rb:93:in `initialize'
      /Users/Thoughtworker/repos/rackspace/excon/lib/excon.rb:143:in `new'
      /Users/Thoughtworker/repos/rackspace/excon/lib/excon.rb:143:in `new'
      /Users/Thoughtworker/repos/rackspace/excon/tests/errors_tests.rb:5:in `block (2 levels) in <top (required)>'
```

It's hard to tell what tripped up Excon.  I don't think Excon supports a default URI scheme, so I added the bare minimum assertion - making sure the URI has a scheme.

Note: I thought about putting the check in Excon::Connection, but then I'd need to manually reconstruct the URI if I want to include it in the error message.
