### PR TITLE
Add the :host symbol to the valid request keys list

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -43,6 +43,7 @@ module Excon
     :debug_response,
     :expects,
     :headers,
+    :host,
     :idempotent,
     :instrumentor,
     :instrumentor_name,


### PR DESCRIPTION
I've been getting this issue:

```
Invalid Excon request keys: :host
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/excon-0.27.6/lib/excon/connection.rb:232:in `request'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/fog-1.16.0/lib/fog/xml/sax_parser_connection.rb:36:in `request'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/fog-1.16.0/lib/fog/core/deprecated/connection.rb:18:in `request'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/fog-1.16.0/lib/fog/aws/elb.rb:187:in `_request'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/fog-1.16.0/lib/fog/aws/elb.rb:182:in `request'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/fog-1.16.0/lib/fog/aws/requests/elb/describe_instance_health.rb:27:in `describe_instance_health'
/Users/alfredmoreno/repo/operations/libexec/ops-elb-describe:45:in `load_balancer_health'
/Users/alfredmoreno/repo/operations/libexec/ops-elb-describe:97:in `block in <main>'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `call'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run_machine'
/Users/alfredmoreno/.rvm/gems/ruby-2.0.0-p0/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
```

Since I updated to the latest versions of Fog/Excon. I added the `:host` symbol to the valid request keys list and it fixed the issue.
