### PR TITLE
Fixed issue with redirect follower middleware not passing on schema, host, and port when the Location value in the header was relative.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .DS_Store
 .yardoc
 .rvmrc
+.ruby-version
+.ruby-gemset
 coverage
 doc
 rdoc

--- a/lib/excon/middlewares/redirect_follower.rb
+++ b/lib/excon/middlewares/redirect_follower.rb
@@ -23,9 +23,9 @@ module Excon
             params[:headers].delete('Proxy-Authorization')
             params[:headers].delete('Host')
             params.merge!(
-              :scheme     => uri.scheme,
-              :host       => uri.host,
-              :port       => uri.port,
+              :scheme     => uri.scheme || datum[:scheme],
+              :host       => uri.host   || datum[:host],
+              :port       => uri.port   || datum[:port],
               :path       => uri.path,
               :query      => uri.query,
               :user       => (URI.decode(uri.user) if uri.user),

--- a/tests/middlewares/redirect_follower_tests.rb
+++ b/tests/middlewares/redirect_follower_tests.rb
@@ -30,3 +30,36 @@ Shindo.tests('Excon redirector support') do
 
   env_restore
 end
+
+Shindo.tests('Excon redirect support for relative Location headers') do
+  env_init
+  
+  connection = Excon.new(
+    'http://127.0.0.1:9292',
+    :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
+    :mock         => true
+  )
+
+  Excon.stub(
+    { :path => '/old' },
+    {
+      :headers  => { 'Location' => '/new' },
+      :body     => 'old',
+      :status   => 301
+    }
+  )
+
+  Excon.stub(
+    { :path => '/new' },
+    {
+      :body     => 'new',
+      :status   => 200
+    }
+  )
+
+  tests("request(:method => :get, :path => '/old').body").returns('new') do
+    connection.request(:method => :get, :path => '/old').body
+  end
+  
+  env_restore
+end


### PR DESCRIPTION
Also added .ruby-version and .ruby-gemset to .gitignore.
