### PR TITLE
remove usage of obsolete URI.decode method

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -10,6 +10,7 @@ require 'timeout'
 require 'uri'
 require 'zlib'
 require 'stringio'
+require 'webrick/httputils'
 
 # Define defaults first so they will be available to other files
 module Excon
@@ -139,8 +140,8 @@ module Excon
         :port       => uri.port,
         :query      => uri.query,
         :scheme     => uri.scheme,
-        :user       => (URI.decode(uri.user) if uri.user),
-        :password   => (URI.decode(uri.password) if uri.password),
+        :user       => (WEBrick::HTTPUtils.unescape(uri.user) if uri.user),
+        :password   => (WEBrick::HTTPUtils.unescape(uri.password) if uri.password),
       }.merge!(params)
       Excon::Connection.new(params)
     end


### PR DESCRIPTION
The standard library call `URI.unescape` has been obsolete for a while, this
should be changed to something that is more appropriate. The call excon uses is
`URI.decode` which calls `URI.unescape`

https://github.com/geemus/excon/blob/master/lib/excon.rb#L142-L143

``` ruby
:user       => (URI.decode(uri.user) if uri.user),
:password   => (URI.decode(uri.password) if uri.password),
```

This is a sample the output when running ruby with `-w`

``` shell
jeremy@ample:~/repos/git/excon ruby-1.9.3-p448@excon master % cat x.rb
require 'excon'
Excon.new( 'http://username:password@example.com/thing' )

jeremy@ample:~/repos/git/excon ruby-1.9.3-p448@excon master % ruby -Ilib -w x.rb
/opt/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/openssl/ssl-internal.rb:91: warning: assigned but unused variable - id
/opt/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/forwardable.rb:199: warning: method redefined; discarding old close
/opt/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/forwardable.rb:199: warning: previous definition of close was here
/Users/jeremy/repos/git/excon/lib/excon.rb:142:in `new': warning: URI.unescape is obsolete
/Users/jeremy/repos/git/excon/lib/excon.rb:143:in `new': warning: URI.unescape is obsolete
excon-0.29.0/lib/excon.rb:143:in `new': warning: URI.unescape is obsolete
excon-0.29.0/lib/excon.rb:142:in `new': warning: URI.unescape is obsolete
```

It appears from the discussion on ruby-core
https://www.ruby-forum.com/topic/207489 that the appropriate replacement should
be `WEBrick::HTTPUtils.unescape`.

With this pull request, the obsoleted `URI.unescape` method is not longer used and the warnings for this item are eliminated.

``` shell
jeremy@ample:~/repos/git/excon ruby-1.9.3-p448@excon eliminate-ruby-warnings % ruby -Ilib -w x.rb
/opt/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/openssl/ssl-internal.rb:91: warning: assigned but unused variable - id
/opt/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/forwardable.rb:199: warning: method redefined; discarding old close
/opt/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/forwardable.rb:199: warning: previous definition of close was here
```
