### PR TITLE
fix for `#ord` in 1.8.7

### DIFF
--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -74,7 +74,7 @@ module Excon
     def escape_uri(str)
       str = str.dup
       str.force_encoding('BINARY') if FORCE_ENC
-      str.gsub!(UNESCAPED) { "%%%02X" % $1.ord }
+      str.gsub!(UNESCAPED) { "%%%02X" % $1[0].ord }
       str
     end
 


### PR DESCRIPTION
I think this should fix tests for geemus/excon#356
