### PR TITLE
Namespaces EOFError appropriately

### DIFF
--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -4,6 +4,8 @@ module Excon
     class Error < StandardError; end
     class StubNotFound < StandardError; end
 
+    class EOFError < Error; end
+
     class SocketError < Error
       attr_reader :socket_error
 


### PR DESCRIPTION
Handling an `EOFError` like other errors is not currently possible because they are not namespaced under `Excon::Errors`.
