### PR TITLE
Support setting ssl_verify_callback

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -77,6 +77,7 @@ module Excon
     :scheme,
     :socket,
     :ssl_ca_file,
+    :ssl_verify_callback,
     :ssl_verify_peer,
     :ssl_version,
     :tcp_nodelay,

--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -9,7 +9,7 @@ module Excon
 
       def initialize(socket_error=nil)
         if socket_error.message =~ /certificate verify failed/
-          super("Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs`, `ENV['SSL_CERT_DIR'] = path_to_certs`, `Excon.defaults[:ssl_ca_file] = path_to_file`, `ENV['SSL_CERT_FILE'] = path_to_file` or `Excon.defaults[:ssl_verify_peer] = false` (less secure).")
+          super("Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs`, `ENV['SSL_CERT_DIR'] = path_to_certs`, `Excon.defaults[:ssl_ca_file] = path_to_file`, `ENV['SSL_CERT_FILE'] = path_to_file`, `Excon.defaults[:ssl_verify_callback] = callback` (see OpenSSL::SSL::SSLContext#verify_callback), or `Excon.defaults[:ssl_verify_peer] = false` (less secure).")
         else
           super("#{socket_error.message} (#{socket_error.class})")
         end

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -47,6 +47,10 @@ module Excon
             Excon.display_warning("Excon unable to add file to cert store, ignoring: #{ca_file}\n[#{e.class}] #{e.message}")
           end
         end
+
+        if verify_callback = @data[:ssl_verify_callback]
+          ssl_context.verify_callback = verify_callback
+        end
       else
         # turn verification off
         ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
This is to support TLS certificate pinning by providing a custom callback, e.g.:

``` ruby
tls_pin = "a-hash-of-the-expected-certificate"

Excon.new(
  url,
  ssl_verify_callback: proc { |preverify_ok, ssl_context|
    Digest::SHA256.new.digest(ssl_context.current_cert.to_der) == tls_pin
  }
)
```
