### PR TITLE
Don't try reading non-file objects

### DIFF
--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -3,6 +3,7 @@ module Excon
 
     class Error < StandardError; end
     class StubNotFound < StandardError; end
+    class InvalidStub < StandardError; end
 
     class SocketError < Error
       attr_reader :socket_error

--- a/lib/excon/middlewares/mock.rb
+++ b/lib/excon/middlewares/mock.rb
@@ -4,7 +4,7 @@ module Excon
       def request_call(datum)
         if datum[:mock]
           # convert File/Tempfile body to string before matching:
-          unless datum[:body].nil? || datum[:body].is_a?(String)
+          if datum[:body].respond_to?(:read)
            if datum[:body].respond_to?(:binmode)
              datum[:body].binmode
            end
@@ -12,6 +12,8 @@ module Excon
              datum[:body].rewind
            end
            datum[:body] = datum[:body].read
+          elsif !datum[:body].nil? && !datum[:body].is_a?(String)
+            raise Excon::Errors::InvalidStub.new("Request body should be a string or an IO object. #{datum[:body].class} provided")
           end
 
           if stub = Excon.stub_for(datum)

--- a/tests/middlewares/mock_tests.rb
+++ b/tests/middlewares/mock_tests.rb
@@ -132,6 +132,12 @@ Shindo.tests('Excon stubs') do
 
   end
 
+  tests("invalid stub response").raises(Excon::Errors::InvalidStub) do
+    Excon.stub({:body => 42, :method => :get}, {:status => 200})
+    connection = Excon.new('http://127.0.0.1:9292', :mock => true)
+    connection.request(:body => 42, :method => :get, :path => '/').status
+  end
+
   tests("mismatched stub").raises(Excon::Errors::StubNotFound) do
     Excon.stub({:method => :post}, {:body => 'body'})
     Excon.get('http://127.0.0.1:9292/', :mock => true)


### PR DESCRIPTION
When a request is made with a body that's not a string, we try reading the object as a file.
Though it might not be a file object. In which case,we're going to end up with a `undefined method`read' for 42:Fixnum (NoMethodError)` error, which can be quite cryptic.

This avoids considering a body as a file unless it responds to `read?`, to prevent that cryptic error.
