### PR TITLE
Content length detection - Edge case ruby2.0.0p195

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -359,8 +359,14 @@ module Excon
 
     private
 
+    # We needed to add :length method because the StringIO class
+    #   in ruby 2.0.0p195 returns nil even when StringIO
+    #   was instantiated with a valid string.
     def detect_content_length(body)
-      if body.respond_to?(:size)
+      if body.respond_to?(:length)
+        # Edge case for ruby 2.0.0p195 and StringIO class
+        body.length
+      elsif body.respond_to?(:size)
         # IO object: File, Tempfile, StringIO, etc.
         body.size
       elsif body.respond_to?(:stat)


### PR DESCRIPTION
We're using ruby 2.0.0p195 and Neography gem that includes excon as a dependency. When we
execute any Neography query in a Before block(test environment) the
first request is done and everything is fine until the second request is
executed.

When the second request is executed, the method Excon::Connection#detect_content_length brakes all
our test suite. We're using instances of StringIO and when it calls to
"size" inside the method mentioned above it returns nil. The weird thing
is that the StringIO instance is created with the same string in both two cases(first and second request)
but it only fails for the fisrt request(TOO WEIRD :P).

We debugged Neography and then Excon and it took us until this point
and until that method. Our solution was to extract the content length from the :length method before using the :size one.
That fixed our problem and it looks good now.

We hope to help more people who is having the same issue than us.
