### PR TITLE
fix double delegate warning

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -17,7 +17,7 @@ module Excon
 
     attr_reader :remote_ip
 
-    def_delegators(:@socket, :close,    :close)
+    def_delegators(:@socket, :close)
 
     def initialize(data = {})
       @data = data


### PR DESCRIPTION
ruby issues the following warning when using excon:

```
/home/bene/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/forwardable.rb:181: warning: method redefined; discarding old close
/home/bene/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/forwardable.rb:181: warning: previous definition of close was here
```

this patch fixes the double delegation
