### PR TITLE
Add support for proxies running on a Unix domain socket

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -396,7 +396,6 @@ module Excon
             @data[:proxy] = ENV['https_proxy'] || ENV['HTTPS_PROXY']
           elsif (ENV.has_key?('http_proxy') || ENV.has_key?('HTTP_PROXY'))
             @data[:proxy] = ENV['http_proxy'] || ENV['HTTP_PROXY']
-            @data[:proxy_socket] = ENV['http_proxy_socket'] || ENV['HTTP_PROXY_SOCKET']
           end
         end
 
@@ -409,6 +408,8 @@ module Excon
           uri = URI.parse(@data[:proxy])
           @data[:proxy] = {
             :host       => uri.host,
+            # path is only sensible for a Unix socket proxy
+            :path       => uri.scheme == UNIX ? uri.path : nil,
             :port       => uri.port,
             :scheme     => uri.scheme,
           }
@@ -422,8 +423,6 @@ module Excon
             if @data[:proxy][:host]
               raise ArgumentError, "The `:host` parameter should not be set for `unix://` proxies.\n" +
                                    "When supplying a `unix://` URI, it should start with `unix:/` or `unix:///`."
-            elsif !@data[:proxy_socket]
-              raise ArgumentError, 'You must provide a `:proxy_socket` for `unix://` proxies'
             end
           else
             unless uri.host && uri.port && uri.scheme

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -78,7 +78,6 @@ module Excon
     :password,
     :port,
     :proxy,
-    :proxy_socket,
     :scheme,
     :socket,
     :ssl_ca_file,

--- a/lib/excon/unix_socket.rb
+++ b/lib/excon/unix_socket.rb
@@ -5,8 +5,10 @@ module Excon
 
     def connect
       @socket  = ::Socket.new(::Socket::AF_UNIX, ::Socket::SOCK_STREAM, 0)
-      sockaddr = ::Socket.sockaddr_un(@data[:proxy_socket] || @data[:socket])
-
+      # If a Unix proxy was specified, the :path option will be set for it,
+      # otherwise fall back to the :socket option.
+      proxy_path = @data[:proxy] ? @data[:proxy][:path] : nil
+      sockaddr = ::Socket.sockaddr_un(proxy_path || @data[:socket])
       if @nonblock
         begin
           @socket.connect_nonblock(sockaddr)

--- a/tests/proxy_tests.rb
+++ b/tests/proxy_tests.rb
@@ -31,7 +31,7 @@ Shindo.tests('Excon proxy support') do
       connection = nil
 
       tests('connection.data[:proxy][:host]').returns(nil) do
-        connection = Excon.new('http://foo.com', :proxy => 'unix:///', :proxy_socket => '/tmp/myproxy.sock')
+        connection = Excon.new('http://foo.com', :proxy => 'unix:///tmp/myproxy.sock')
         connection.data[:proxy][:host]
       end
 
@@ -43,8 +43,8 @@ Shindo.tests('Excon proxy support') do
         connection.data[:proxy][:scheme]
       end
 
-      tests('connection.data[:proxy_socket]').returns('/tmp/myproxy.sock') do
-        connection.data[:proxy_socket]
+      tests('connection.data[:proxy][:path]').returns('/tmp/myproxy.sock') do
+        connection.data[:proxy][:path]
       end
     end
 
@@ -161,8 +161,7 @@ Shindo.tests('Excon proxy support') do
 
     tests('with a unix socket proxy config from the environment') do
       env_init({
-        'http_proxy' => 'unix:///',
-        'http_proxy_socket' => '/tmp/myproxy.sock'
+        'http_proxy' => 'unix:///tmp/myproxy.sock',
       })
 
       tests('an https connection') do
@@ -181,8 +180,8 @@ Shindo.tests('Excon proxy support') do
           connection.data[:proxy][:scheme]
         end
 
-        tests('connection.data[:proxy_socket]').returns('/tmp/myproxy.sock') do
-          connection.data[:proxy_socket]
+        tests('connection.data[:proxy][:path]').returns('/tmp/myproxy.sock') do
+          connection.data[:proxy][:path]
         end
       end
 
@@ -258,7 +257,7 @@ Shindo.tests('Excon proxy support') do
       response = nil
 
       tests('response.status').returns(200) do
-        connection = Excon.new('http://foo.com:8080', :proxy => 'unix:///', :proxy_socket => '/tmp/myproxy.sock')
+        connection = Excon.new('http://foo.com:8080', :proxy => 'unix:///tmp/myproxy.sock')
         response = connection.request(:method => :get, :path => '/bar', :query => {:alpha => 'kappa'})
 
         response.status


### PR DESCRIPTION
I really like that Excon supports HTTP connections via a Unix domain socket, and the purpose of this pull is to extend this functionality to support proxies running over Unix domain sockets as well.

The current syntax for connecting to a Unix socket looks like this:

``` ruby
connection = Excon.new('unix:///', :socket => '/tmp/unicorn.sock')
```

I've tried to stay true to this by mirroring it in the proxy settings:

``` ruby
connection = Excon.new('unix:///', :socket => '/tmp/unicorn.sock',
  :proxy => 'unix:///', :proxy_socket => '/tmp/proxy.sock')
```

As with current proxy settings, these can be overwritten by config vars as well:

``` bash
HTTP_PROXY=unix:/// HTTP_PROXY_SOCKET=/tmp/proxy.sock ./myapp
```

I think the biggest problem with this technique is that things get a little fuzzy once SSL proxies are combined with the Unix settings (i.e. no SSL Unix socket is possible, although a Unix socket proxy can proxy an SSL connection with no trouble). I think this is mostly okay because:
- Connections to a Unix domain socket via SSL are already not really supported as far as I can tell (`UnixSocket` and `SSLSocket` are different classes and don't compose).
- I don't think there's a huge use case for securing communication within the computer with SSL.

@geemus I mostly want to gauge your impressions on whether this is a reasonable idea. If so, I'll try to clean-up the code where I can and add an appropriate test suite. Thanks!
