### PR TITLE
Remove "General Documentation" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,6 @@ Either of these should allow you to work around the socket error and continue wi
 
 ## Getting Help
 
-* [General Documentation](http://excon.io).
 * Ask specific questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/excon).
 * Report bugs and discuss potential features in [Github issues](https://github.com/excon/excon/issues).
 


### PR DESCRIPTION
This link in the README does not show any documentation at all. Instead, it gives me a link to GitHub (twice), some archives and it tells me who it was maintained by.

Where did the General Documentation stuff go?
