### PR TITLE
Rescue illegal seek exception when rewinding IOs that can't actually seek

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -158,8 +158,8 @@ module Excon
             if body.respond_to?(:binmode)
               body.binmode
             end
-            if body.respond_to?(:pos=)
-              body.pos = 0
+            if body.respond_to?(:rewind)
+              body.rewind  rescue nil
             end
             while chunk = body.read(datum[:chunk_size])
               socket.write(chunk)


### PR DESCRIPTION
Fix for #441
