### PR TITLE
Add ssl_cert_store option for custom CA certificate store.

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -82,6 +82,7 @@ module Excon
     :socket,
     :ssl_ca_file,
     :ssl_ca_path,
+    :ssl_cert_store,
     :ssl_verify_callback,
     :ssl_verify_peer,
     :ssl_verify_peer_host,

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -35,9 +35,12 @@ module Excon
         if ca_path = ENV['SSL_CERT_DIR'] || @data[:ssl_ca_path]
           ssl_context.ca_path = ca_path
         end
+        if cert_store = @data[:ssl_cert_store]
+          ssl_context.cert_store = cert_store
+        end
 
         # no defaults, fallback to bundled
-        unless ca_file || ca_path
+        unless ca_file || ca_path || cert_store
           ssl_context.cert_store = OpenSSL::X509::Store.new
           ssl_context.cert_store.set_default_paths
 

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -144,6 +144,25 @@ Shindo.tests('Excon ssl verify peer (ssl)') do
   end
 end
 
+Shindo.tests('Excon ssl verify peer (ssl cert store)') do
+  with_rackup('ssl.ru') do
+    connection = nil
+    test do
+      ssl_ca_cert = File.read(File.join(File.dirname(__FILE__), 'data', '127.0.0.1.cert.crt'))
+      ssl_cert_store = OpenSSL::X509::Store.new
+      ssl_cert_store.add_cert OpenSSL::X509::Certificate.new ssl_ca_cert
+      connection = Excon.new('https://127.0.0.1:9443', :ssl_verify_peer => true, :ssl_cert_store => ssl_cert_store )
+      true
+    end
+
+    tests('response.status').returns(200) do
+      response = connection.request(:method => :get, :path => '/content-length/100')
+
+      response.status
+    end
+  end
+end
+
 Shindo.tests('Excon basics (ssl file)',['focus']) do
   with_rackup('ssl_verify_peer.ru') do
 


### PR DESCRIPTION
I want to specify all the SSL options using strings (coming from a database) instead of file paths. excon already has the `certificate` option for the client certificate and `private_key` for the client private key, but it doesn't seem to have an option for passing in a CA certificate.

After reading the ssl_socket code, I figured that it'd be better to add an option for specifying a custom `OpenSSL::X509::Store`. My code can create a store and add a certificate to it, just like in the test in this PR.

I look forward to your feedback. I hope I can address any issue that comes up, and hope to get this functionality merged.

Thank you very much!
