### PR TITLE
No basic auth on redirect

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -69,7 +69,7 @@ module Excon
       end
 
       # Use Basic Auth if url contains a login
-      if @data.has_key?(:user) || @data.has_key?(:password)
+      if @data[:user] || @data[:password]
         user, pass = Utils.unescape_form(@data[:user].to_s), Utils.unescape_form(@data[:password].to_s)
         @data[:headers]['Authorization'] ||= 'Basic ' << ['' << user.to_s << ':' << pass.to_s].pack('m').delete(Excon::CR_NL)
       end

--- a/lib/excon/middlewares/redirect_follower.rb
+++ b/lib/excon/middlewares/redirect_follower.rb
@@ -28,10 +28,11 @@ module Excon
               :host       => uri.host   || datum[:host],
               :port       => uri.port   || datum[:port],
               :path       => uri.path,
-              :query      => uri.query,
-              :user       => (Utils.unescape_uri(uri.user) if uri.user),
-              :password   => (Utils.unescape_uri(uri.password) if uri.password)
+              :query      => uri.query
             )
+
+            params.merge!(:user => Utils.unescape_uri(uri.user)) if uri.user
+            params.merge!(:password => Utils.unescape_uri(uri.password)) if uri.password
 
             response = Excon::Connection.new(params).request
             datum.merge!({:response => response.data})


### PR DESCRIPTION
- Fixes a bug where nil (empty) Basic Auth is added to a request after
  redirect
- Fixes the other side of the equation where `user` and `password` keys were sent to `Excon::Connection` but their values were `nil`, we should not add empty Authorization header in that case.
- ~~Introduces Rspec tests as a means of testing only the
  Excon::Middleware::RedirectFollower class and stub out other
  interacting classes -- note that minitest does not provide this kind of doubling, mocking, or stubbing to expect `Excon::Connection.new` to be called with certain params.~~
- Note that the Shindo tests did not fail for these changes, and that points me towards needing this finer-grained class testing to make sure we're handling edge cases for internal behavior correctly (things that can't be detected by what's in the response)
