### PR TITLE
Allow disabling of proxies with proxy: false

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -392,6 +392,13 @@ module Excon
     end
 
     def setup_proxy
+      if @data[:disable_proxy]
+        if @data[:proxy]
+          raise ArgumentError, "`:disable_proxy` parameter and `:proxy` parameter cannot both be set at the same time."
+        end
+        return
+      end
+
       unless @data[:scheme] == UNIX
         if no_proxy_env = ENV["no_proxy"] || ENV["NO_PROXY"]
           no_proxy_list = no_proxy_env.scan(/\*?\.?([^\s,:]+)(?::(\d+))?/i).map { |s| [s[0], s[1]] }

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -67,6 +67,7 @@ module Excon
     :client_cert,
     :certificate,
     :certificate_path,
+    :disable_proxy,
     :private_key,
     :private_key_path,
     :connect_timeout,

--- a/tests/proxy_tests.rb
+++ b/tests/proxy_tests.rb
@@ -66,6 +66,15 @@ Shindo.tests('Excon proxy support') do
         tests('connection.data[:proxy][:scheme]').returns('http') do
           connection.data[:proxy][:scheme]
         end
+
+        tests('with disable_proxy set') do
+          connection = nil
+
+          tests('connection.data[:proxy]').returns(nil) do
+            connection = Excon.new('http://foo.com', :disable_proxy => true)
+            connection.data[:proxy]
+          end
+        end
       end
 
       tests('an https connection') do
@@ -82,6 +91,15 @@ Shindo.tests('Excon proxy support') do
 
         tests('connection.data[:proxy][:scheme]').returns('http') do
           connection.data[:proxy][:scheme]
+        end
+
+        tests('with disable_proxy set') do
+          connection = nil
+
+          tests('connection.data[:proxy]').returns(nil) do
+            connection = Excon.new('https://foo.com', :disable_proxy => true)
+            connection.data[:proxy]
+          end
         end
       end
 


### PR DESCRIPTION
With the current setup in Excon, it's more complicated to opt-out of proxies when they are set through `ENV['HTTPS_PROXY']`, since you have to explicitly whitelist the host through another `ENV` variable. It's a lot easier to do it when we create our Excon config by setting `proxy: false`.

Alternatively, if you want to be sure there isn't a regression, I could change it to something like `disable_proxies: true`.
