### PR TITLE
Re-implement timeout monitoring with IO.select

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -10,6 +10,7 @@ module Excon
       Excon.display_warning('Excon::Socket#params is deprecated use Excon::Socket#data instead.')
       @data
     end
+
     def params=(new_params)
       Excon.display_warning('Excon::Socket#params= is deprecated use Excon::Socket#data= instead.')
       @data = new_params
@@ -24,119 +25,56 @@ module Excon
       @nonblock = data[:nonblock]
       @read_buffer = ''
       @eof = false
-
       connect
     end
 
-    def read(max_length=nil)
+    def read(max_length = nil)
       if @eof
         return max_length ? nil : ''
       elsif @nonblock
-        begin
-          if max_length
-            until @read_buffer.length >= max_length
-              @read_buffer << @socket.read_nonblock(max_length - @read_buffer.length)
-            end
-          else
-            while true
-              @read_buffer << @socket.read_nonblock(@data[:chunk_size])
-            end
-          end
-        rescue OpenSSL::SSL::SSLError => error
-          if error.message == 'read would block'
-            if IO.select([@socket], nil, nil, @data[:read_timeout])
-              retry
-            else
-              raise(Excon::Errors::Timeout.new("read timeout reached"))
-            end
-          else
-            raise(error)
-          end
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable
-          if @read_buffer.empty?
-            # if we didn't read anything, try again...
-            if IO.select([@socket], nil, nil, @data[:read_timeout])
-              retry
-            else
-              raise(Excon::Errors::Timeout.new("read timeout reached"))
-            end
-          end
-        rescue EOFError
-          @eof = true
-        end
-
-        if max_length
-          if @read_buffer.empty?
-            nil # EOF met at beginning
-          else
-            @read_buffer.slice!(0, max_length)
-          end
-        else
-          # read until EOFError, so return everything
-          @read_buffer.slice!(0, @read_buffer.length)
-        end
-      else
-        begin
-          Timeout.timeout(@data[:read_timeout]) do
-            @socket.read(max_length)
-          end
-        rescue Timeout::Error
-          raise Excon::Errors::Timeout.new('read timeout reached')
-        end
+        read_nonblock(max_length) 
+      else 
+        read_block(max_length)
       end
     end
 
     def readline
+      return legacy_readline if RUBY_VERSION.to_f <= 1.8_7
       begin
+        buffer = ''
+        buffer << @socket.read_nonblock(1) while buffer[-1] != "\n"
+        buffer
+      rescue Errno::EAGAIN
+        if timeout_reached('read') 
+          raise_timeout_error('read') 
+        else
+          retry
+        end
+      rescue OpenSSL::SSL::SSLError => e
+        if e.message == 'read would block'
+          if timeout_reached('read') 
+            raise_timeout_error('read') 
+          else
+            retry
+          end
+        else
+          raise(error)
+        end
+      end
+    end
+
+    def legacy_readline
+       begin
         Timeout.timeout(@data[:read_timeout]) do
           @socket.readline
-        end
+      end
       rescue Timeout::Error
-        raise Excon::Errors::Timeout.new('read timeout reached')
+      raise Excon::Errors::Timeout.new('read timeout reached')
       end
     end
 
     def write(data)
-      if @nonblock
-        if FORCE_ENC
-          data.force_encoding('BINARY')
-        end
-        while true
-          written = nil
-          begin
-            # I wish that this API accepted a start position, then we wouldn't
-            # have to slice data when there is a short write.
-            written = @socket.write_nonblock(data)
-          rescue OpenSSL::SSL::SSLError, Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable => error
-            if error.is_a?(OpenSSL::SSL::SSLError) && error.message != 'write would block'
-              raise error
-            else
-              if IO.select(nil, [@socket], nil, @data[:write_timeout])
-                retry
-              else
-                raise Excon::Errors::Timeout.new('write timeout reached')
-              end
-            end
-          end
-
-          # Fast, common case.
-          break if written == data.size
-
-          # This takes advantage of the fact that most ruby implementations
-          # have Copy-On-Write strings. Thusly why requesting a subrange
-          # of data, we actually don't copy data because the new string
-          # simply references a subrange of the original.
-          data = data[written, data.size]
-        end
-      else
-        begin
-          Timeout.timeout(@data[:write_timeout]) do
-            @socket.write(data)
-          end
-        rescue Timeout::Error
-          raise(Excon::Errors::Timeout.new('write timeout reached'))
-        end
-      end
+      @nonblock ? write_nonblock(data) : write_block(data)
     end
 
     def local_address
@@ -181,27 +119,19 @@ module Excon
             end
           end
 
-          begin
-            Timeout.timeout(@data[:connect_timeout]) do
-              if @nonblock
-                socket.connect_nonblock(sockaddr)
-              else
-                socket.connect(sockaddr)
-              end
-            end
-          rescue Timeout::Error
-            raise Excon::Errors::Timeout.new('connect timeout reached')
+          if @nonblock
+            socket.connect_nonblock(sockaddr)
+          else
+            socket.connect(sockaddr)
           end
-
           @socket = socket
           break
         rescue Errno::EINPROGRESS
           unless IO.select(nil, [socket], nil, @data[:connect_timeout])
-            raise(Excon::Errors::Timeout.new("connect timeout reached"))
+            raise(Excon::Errors::Timeout.new('connect timeout reached'))
           end
           begin
             socket.connect_nonblock(sockaddr)
-
             @socket = socket
             break
           rescue Errno::EISCONN
@@ -217,16 +147,144 @@ module Excon
         end
       end
 
-      unless @socket
-        # this will be our last encountered exception
-        raise exception
-      end
+      # this will be our last encountered exception
+      fail exception unless @socket
 
       if @data[:tcp_nodelay]
         @socket.setsockopt(::Socket::IPPROTO_TCP,
                            ::Socket::TCP_NODELAY,
                            true)
       end
+    end
+
+    def read_nonblock(max_length)
+      begin
+            if max_length
+              until @read_buffer.length >= max_length
+                @read_buffer << @socket.read_nonblock(max_length - @read_buffer.length)
+              end
+            else
+              loop do
+                @read_buffer << @socket.read_nonblock(@data[:chunk_size])
+              end
+            end
+          rescue OpenSSL::SSL::SSLError => error
+            if error.message == 'read would block'
+              if timeout_reached('read')  
+                raise_timeout_error('read') 
+              else 
+                retry
+              end
+            else
+              raise(error)
+            end
+          rescue Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable
+            if @read_buffer.empty?
+              # if we didn't read anything, try again...
+              if timeout_reached('read') 
+                raise_timeout_error('read') 
+              else
+                retry
+              end
+            end
+          rescue EOFError
+            @eof = true
+          end
+
+      if max_length
+        if @read_buffer.empty?
+          nil # EOF met at beginning
+        else
+          @read_buffer.slice!(0, max_length)
+        end
+      else
+        # read until EOFError, so return everything
+        @read_buffer.slice!(0, @read_buffer.length)
+      end
+    end
+
+    def read_block(max_length)
+      @socket.read(max_length)
+    rescue OpenSSL::SSL::SSLError => error
+      if error.message == 'read would block'
+        if timeout_reached('read') 
+          raise_timeout_error('read') 
+        else
+          retry
+        end
+      else
+        raise(error)
+      end
+    rescue Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable
+      if @read_buffer.empty?
+        if timeout_reached('read') 
+          raise_timeout_error('read') 
+        else
+          retry
+        end
+      end
+    rescue EOFError
+      @eof = true
+    end
+
+    def write_nonblock(data)
+      if FORCE_ENC
+        data.force_encoding('BINARY')
+          end
+      loop do
+        written = nil
+        begin
+          # I wish that this API accepted a start position, then we wouldn't
+          # have to slice data when there is a short write.
+          written = @socket.write_nonblock(data)
+        rescue OpenSSL::SSL::SSLError, Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable => error
+          if error.is_a?(OpenSSL::SSL::SSLError) && error.message != 'write would block'
+            raise error
+          else
+            if timeout_reached('write') 
+              raise_timeout_error('write') 
+            else 
+              retry
+            end
+          end
+        end
+
+        # Fast, common case.
+        break if written == data.size
+
+        # This takes advantage of the fact that most ruby implementations
+        # have Copy-On-Write strings. Thusly why requesting a subrange
+        # of data, we actually don't copy data because the new string
+        # simply references a subrange of the original.
+        data = data[written, data.size]
+      end
+    end
+
+    def write_block(data)
+      @socket.write(data)
+    rescue OpenSSL::SSL::SSLError, Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable => error
+      if error.is_a?(OpenSSL::SSL::SSLError) && error.message != 'write would block'
+        raise error
+      else
+        if timeout_reached('write') 
+          raise_timeout_error('write') 
+        else
+          retry
+        end
+      end
+    end
+
+    def timeout_reached(type)
+      if type == 'read'
+        args = [[@socket], nil, nil, @data[:read_timeout]]
+      else
+        args = [nil, [@socket], nil, @data[:write_timeout]]
+      end
+      IO.select(*args) ? nil : true
+    end
+
+    def raise_timeout_error(type)
+      fail Excon::Errors::Timeout.new("#{type} timeout reached")
     end
 
     def unpacked_sockaddr
@@ -236,6 +294,5 @@ module Excon
         raise
       end
     end
-
   end
 end


### PR DESCRIPTION
 - decompose write into write_nonblock and write_block
 - decompose read into read_nonblock and read_block
 - added timeout_reached() and raise_timeout_error() to make monitoring DRY