### PR TITLE
Pass ipv6 safe address to socket layer

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -111,6 +111,7 @@ module Excon
       end
       params = {
         :host       => uri.host,
+        :hostname   => uri.hostname,
         :path       => uri.path,
         :port       => uri.port,
         :query      => uri.query,

--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -11,6 +11,8 @@ require 'uri'
 require 'zlib'
 require 'stringio'
 
+require 'excon/extensions/uri'
+
 require 'excon/middlewares/base'
 require 'excon/middlewares/expects'
 require 'excon/middlewares/idempotent'

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -428,6 +428,7 @@ module Excon
           uri = @data[:proxy].is_a?(String) ? URI.parse(@data[:proxy]) : @data[:proxy]
           @data[:proxy] = {
             :host       => uri.host,
+            :hostname   => uri.hostname,
             # path is only sensible for a Unix socket proxy
             :path       => uri.scheme == UNIX ? uri.path : nil,
             :port       => uri.port,

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -35,7 +35,8 @@ module Excon
     #   @param [Hash<Symbol, >] params One or more optional params
     #     @option params [String] :body Default text to be sent over a socket. Only used if :body absent in Connection#request params
     #     @option params [Hash<Symbol, String>] :headers The default headers to supply in a request. Only used if params[:headers] is not supplied to Connection#request
-    #     @option params [String] :host The destination host's reachable DNS name or IP, in the form of a String
+    #     @option params [String] :host The destination host's reachable DNS name or IP, in the form of a String. IPv6 addresses must be wrapped (e.g. [::1]).  See URI#host.
+    #     @option params [String] :hostname Same as host, but usable for socket connections. IPv6 addresses must not be wrapped (e.g. ::1).  See URI#hostname.
     #     @option params [String] :path Default path; appears after 'scheme://host:port/'. Only used if params[:path] is not supplied to Connection#request
     #     @option params [Fixnum] :port The port on which to connect, to the destination host
     #     @option params [Hash]   :query Default query; appended to the 'scheme://host:port/path/' in the form of '?key=value'. Will only be used if params[:query] is not supplied to Connection#request
@@ -358,6 +359,12 @@ module Excon
         #params = params.dup
         #invalid_keys.each {|key| params.delete(key) }
       end
+
+      if validation == :connection && params.key?(:host) && !params.key?(:hostname)
+        Excon.display_warning('hostname is missing! For IPv6 support, provide both host and hostname: Excon::Connection#new(:host => uri.host, :hostname => uri.hostname, ...).')
+        params[:hostname] = params[:host]
+      end
+
       params
     end
 

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -73,6 +73,7 @@ module Excon
     :connect_timeout,
     :family,
     :host,
+    :hostname,
     :omit_default_port,
     :nonblock,
     :reuseaddr,

--- a/lib/excon/extensions/uri.rb
+++ b/lib/excon/extensions/uri.rb
@@ -1,0 +1,33 @@
+# TODO: Remove this monkey patch once ruby 1.9.3+ is the minimum supported version.
+#
+# This patch backports URI#hostname to ruby 1.9.2 and older.
+# URI#hostname is used for IPv6 support in Excon.
+#
+# URI#hostname was added in stdlib in v1_9_3_0 in this commit:
+#   https://github.com/ruby/ruby/commit/5fd45a4b79dd26f9e7b6dc41142912df911e4d7d
+#
+# Addressable::URI is also an URI parser accepted in some parts of Excon.
+# Addressable::URI#hostname was added in addressable-2.3.5+ in this commit:
+#   https://github.com/sporkmonger/addressable/commit/1b94abbec1f914d5f707c92a10efbb9e69aab65e
+#
+# Users who want to use Addressable::URI to parse URIs must upgrade to 2.3.5 or newer.
+require 'uri'
+unless URI("http://foo/bar").respond_to?(:hostname)
+  module URI
+    class Generic
+      # extract the host part of the URI and unwrap brackets for IPv6 addresses.
+      #
+      # This method is same as URI::Generic#host except
+      # brackets for IPv6 (and future IP) addresses are removed.
+      #
+      # u = URI("http://[::1]/bar")
+      # p u.hostname      #=> "::1"
+      # p u.host          #=> "[::1]"
+      #
+      def hostname
+        v = self.host
+        /\A\[(.*)\]\z/ =~ v ? $1 : v
+      end
+    end
+  end
+end

--- a/lib/excon/middlewares/redirect_follower.rb
+++ b/lib/excon/middlewares/redirect_follower.rb
@@ -26,6 +26,7 @@ module Excon
             params.merge!(
               :scheme     => uri.scheme || datum[:scheme],
               :host       => uri.host   || datum[:host],
+              :hostname   => uri.hostname || datum[:hostname],
               :port       => uri.port   || datum[:port],
               :path       => uri.path,
               :query      => uri.query

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -155,10 +155,10 @@ module Excon
 
       if @data[:proxy]
         family = @data[:proxy][:family] || ::Socket::Constants::AF_UNSPEC
-        args = [@data[:proxy][:host], @data[:proxy][:port], family, ::Socket::Constants::SOCK_STREAM]
+        args = [@data[:proxy][:hostname], @data[:proxy][:port], family, ::Socket::Constants::SOCK_STREAM]
       else
         family = @data[:family] || ::Socket::Constants::AF_UNSPEC
-        args = [@data[:host], @data[:port], family, ::Socket::Constants::SOCK_STREAM]
+        args = [@data[:hostname], @data[:port], family, ::Socket::Constants::SOCK_STREAM]
       end
       if RUBY_VERSION >= '1.9.2' && defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby'
         args << nil << nil << false # no reverse lookup

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -6,6 +6,7 @@ Shindo.tests('Excon basics') do
       tests('GET /content-length/100').returns(200) do
         connection = Excon::Connection.new({
           :host             => '127.0.0.1',
+          :hostname         => '127.0.0.1',
           :nonblock         => false,
           :port             => 9292,
           :scheme           => 'http',
@@ -169,6 +170,7 @@ Shindo.tests('Excon basics (ssl file)',['focus']) do
     tests('GET /content-length/100').raises(Excon::Errors::SocketError) do
       connection = Excon::Connection.new({
         :host             => '127.0.0.1',
+        :hostname         => '127.0.0.1',
         :nonblock         => false,
         :port             => 8443,
         :scheme           => 'https',
@@ -191,6 +193,7 @@ Shindo.tests('Excon basics (ssl file paths)',['focus']) do
     tests('GET /content-length/100').raises(Excon::Errors::SocketError) do
       connection = Excon::Connection.new({
         :host             => '127.0.0.1',
+        :hostname         => '127.0.0.1',
         :nonblock         => false,
         :port             => 8443,
         :scheme           => 'https',

--- a/tests/middlewares/escape_path_tests.rb
+++ b/tests/middlewares/escape_path_tests.rb
@@ -5,6 +5,7 @@ Shindo.tests('Excon Decompress Middleware') do
       tests('GET /echo%20dirty').returns(200) do
         connection = Excon::Connection.new({
           :host             => '127.0.0.1',
+          :hostname         => '127.0.0.1',
           :middlewares      => Excon.defaults[:middlewares] + [Excon::Middleware::EscapePath],
           :nonblock         => false,
           :port             => 9292,
@@ -20,6 +21,7 @@ Shindo.tests('Excon Decompress Middleware') do
       tests('GET /echo dirty').returns(200) do
         connection = Excon::Connection.new({
           :host             => '127.0.0.1',
+          :hostname         => '127.0.0.1',
           :middlewares      => Excon.defaults[:middlewares] + [Excon::Middleware::EscapePath],
           :nonblock         => false,
           :port             => 9292,

--- a/tests/request_tests.rb
+++ b/tests/request_tests.rb
@@ -2,7 +2,9 @@ Shindo.tests('Request Tests') do
   with_server('good') do
 
     tests('persistent connections') do
-      %w([::1]:9293 127.0.0.1:9292).each do |ip_port|
+      ip_ports = %w(127.0.0.1:9292)
+      ip_ports << "[::1]:9293" unless RUBY_PLATFORM == 'java'
+      ip_ports.each do |ip_port|
 
         tests("with default :persistent => true, #{ip_port}") do
           connection = nil

--- a/tests/request_tests.rb
+++ b/tests/request_tests.rb
@@ -2,55 +2,56 @@ Shindo.tests('Request Tests') do
   with_server('good') do
 
     tests('persistent connections') do
+      %w([::1]:9293 127.0.0.1:9292).each do |ip_port|
 
-      tests('with default :persistent => true') do
-        connection = nil
+        tests("with default :persistent => true, #{ip_port}") do
+          connection = nil
 
-        returns(['1', '2'], 'uses a persistent connection') do
-          connection = Excon.new('http://127.0.0.1:9292', :persistent => true)
-          2.times.map do
-            connection.request(:method => :get, :path => '/echo/request_count').body
+          returns(['1', '2'], 'uses a persistent connection') do
+            connection = Excon.new("http://#{ip_port}", :persistent => true)
+            2.times.map do
+              connection.request(:method => :get, :path => '/echo/request_count').body
+            end
+          end
+
+          returns(['3', '1', '2'], ':persistent => false resets connection') do
+            ret = []
+            ret << connection.request(:method => :get,
+                                      :path   => '/echo/request_count',
+                                      :persistent => false).body
+            ret << connection.request(:method => :get,
+                                      :path   => '/echo/request_count').body
+            ret << connection.request(:method => :get,
+                                      :path   => '/echo/request_count').body
           end
         end
 
-        returns(['3', '1', '2'], ':persistent => false resets connection') do
-          ret = []
-          ret << connection.request(:method => :get,
-                                    :path   => '/echo/request_count',
-                                    :persistent => false).body
-          ret << connection.request(:method => :get,
-                                    :path   => '/echo/request_count').body
-          ret << connection.request(:method => :get,
-                                    :path   => '/echo/request_count').body
-        end
-      end
+        tests("with default :persistent => false, #{ip_port}") do
+          connection = nil
 
-      tests('with default :persistent => false') do
-        connection = nil
+          returns(['1', '1'], 'does not use a persistent connection') do
+            connection = Excon.new("http://#{ip_port}", :persistent => false)
+            2.times.map do
+              connection.request(:method => :get, :path => '/echo/request_count').body
+            end
+          end
 
-        returns(['1', '1'], 'does not use a persistent connection') do
-          connection = Excon.new('http://127.0.0.1:9292', :persistent => false)
-          2.times.map do
-            connection.request(:method => :get, :path => '/echo/request_count').body
+          returns(['1', '2', '3', '1'], ':persistent => true enables persistence') do
+            ret = []
+            ret << connection.request(:method => :get,
+                                      :path   => '/echo/request_count',
+                                      :persistent => true).body
+            ret << connection.request(:method => :get,
+                                      :path   => '/echo/request_count',
+                                      :persistent => true).body
+            ret << connection.request(:method => :get,
+                                      :path   => '/echo/request_count').body
+            ret << connection.request(:method => :get,
+                                      :path   => '/echo/request_count').body
           end
         end
 
-        returns(['1', '2', '3', '1'], ':persistent => true enables persistence') do
-          ret = []
-          ret << connection.request(:method => :get,
-                                    :path   => '/echo/request_count',
-                                    :persistent => true).body
-          ret << connection.request(:method => :get,
-                                    :path   => '/echo/request_count',
-                                    :persistent => true).body
-          ret << connection.request(:method => :get,
-                                    :path   => '/echo/request_count').body
-          ret << connection.request(:method => :get,
-                                    :path   => '/echo/request_count').body
-        end
       end
-
     end
-
   end
 end

--- a/tests/servers/good.rb
+++ b/tests/servers/good.rb
@@ -333,6 +333,6 @@ end
 
 EM.run do
   EM.start_server("127.0.0.1", 9292, GoodServer)
-  EM.start_server("::1", 9293, GoodServer)
+  EM.start_server("::1", 9293, GoodServer) unless RUBY_PLATFORM == 'java'
   $stderr.puts "ready"
 end

--- a/tests/servers/good.rb
+++ b/tests/servers/good.rb
@@ -333,5 +333,6 @@ end
 
 EM.run do
   EM.start_server("127.0.0.1", 9292, GoodServer)
+  EM.start_server("::1", 9293, GoodServer)
   $stderr.puts "ready"
 end


### PR DESCRIPTION
This pull request replaces #449 

The summary is that we need incoming valid URIs as Strings with IPv6 literals to be properly parsed for use at different layers.

For example: "http://[::1]:9292"
We need "::1" for Socket connections
We need "[::1]" for use in URIs and in the Request header's Host field

* In pull request #449, the code in Excon passes down "[::1]" for use everywhere, and the changes in the PR unwrap the address to "::1" for use with sockets.  The problem is that if we have need for "::1" elsewhere such as other socket connections, we need to repeat the process.  It's also duplicating URI#hostname's code.

* In this pull request, we instead pass along both URI#host ("[::1]") and URI#hostname ("::1") to Excon::Connection.new and ensure it's available for use by the Socket layer.  In this way, the Socket code can just use `@data[:hostname]` when it needs an unwrapped host value.  Any future socket code can also make use of this IPv6 safe hostname.

* Note, I researched changing Fog and the externalized fog plugins to pass URIs all over the place but it's a much harder problem and introduces much more risk into Fog and Excon.  This Pull request is much smaller and makes the valid assertion that if you pass a URI as a String, it should be a valid URI.


From the prior Pull Request #449:


Literal IPv6 addresses, such as ::1, have a few rules in regards to their use:
* They must be wrapped in [], such as [::1] when used in URL/URIs and in the Host Request header field.
See: https://bugzilla.mozilla.org/show_bug.cgi?id=45891
TL;DR: 
RFC 2617 says Host = host : port
RFC 2732 says, host must be wrapped in [], so, we need **Host = [::1]:9292**

* They must be unwrapped, "::1", when passed to sockets.
See: https://github.com/ruby/ruby/blob/e70210cad637c5be31709f65c0eb9603f8ec18a1/lib/uri/generic.rb#L234

#### To illustrate the problem that this pull request fixes:
```ruby

irb(main):002:0> Excon.new("http://[::1]:9292").request
Excon::Errors::SocketError: getaddrinfo: nodename nor servname provided, or not known (SocketError)
...
```

#### Same problem in Fog itself:
```ruby
irb(main):001:0> Fog::Core::Connection.new("http://[::1]:9292").request({})
Excon::Errors::SocketError: getaddrinfo: nodename nor servname provided, or not known (SocketError)
```

I get a getaddrinfo error **because Excon is sending [::1]** directly to the socket layer.

```ruby
irb(main):006:0> TCPSocket.new("[::1]", 9292)
SocketError: getaddrinfo: nodename nor servname provided, or not known
```

#### Using this PR's fixed excon:

```ruby
irb(main):002:0> Excon.new("http://[::1]:9292").request
Excon::Errors::SocketError: Connection refused - connect(2) (Errno::ECONNREFUSED)
...
```
**Note 1**: Instead of getaddrinfo error, I get connection refused because I have nothing listening.

#### Finally, using this PR with Fog:
```ruby
irb(main):001:0> Fog::Core::Connection.new("http://[::1]:9292").request({})
Excon::Errors::SocketError: Connection refused - connect(2) for [::1]:9292 (Errno::ECONNREFUSED)
````