### PR TITLE
update rack + fix Rake::DSL warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'jruby-openssl', :platform => :jruby
 gem 'unicorn', :platforms => [:mri, :rbx]
 gem 'rubysl', '~> 2.0', :platform => :rbx
-gem 'rack', '~> 1.5'
+gem 'rack', '~> 1.6'
 
 # group :benchmark do
 #   gem 'em-http-request'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     minitest (4.7.5)
     multi_json (1.3.6)
     open4 (1.3.0)
-    rack (1.5.2)
+    rack (1.6.0)
     rack-protection (1.2.0)
       rack
     raindrops (0.13.0)
@@ -261,7 +261,7 @@ DEPENDENCIES
   excon!
   jruby-openssl
   open4
-  rack (~> 1.5)
+  rack (~> 1.6)
   rake
   rdoc
   rubysl (~> 2.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'rake'
 require 'date'
-
+include Rake::DSL
 #############################################################################
 #
 # Helper functions


### PR DESCRIPTION
1) Fix warning on ```rake -T```
```
$ rake -T
WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.
WARNING: DSL method Shindo::Rake#desc called at /usr/local/rvm/gems/ruby-2.0.0-p598/gems/shindo-0.3.4/lib/shindo/rake.rb:6:in `initialize'
WARNING: DSL method Shindo::Rake#task called at /usr/local/rvm/gems/ruby-2.0.0-p598/gems/shindo-0.3.4/lib/shindo/rake.rb:7:in `initialize'
rake clobber_rdoc  # Remove RDoc HTML files
rake console       # Open an irb session preloaded with this library
rake rdoc          # Build RDoc HTML files
rake rerdoc        # Rebuild RDoc HTML files
rake tests         # Run shindo tests
rake update_certs  # update bundled certs
```
2) Update rake for newest version ( just for fun )