### PR TITLE
Ruby 2.2 support was fixed in eventmachine 1.0.4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,8 @@ GEM
     chronic (0.6.7)
     delorean (2.0.0)
       chronic
-    eventmachine (1.0.0)
-    eventmachine (1.0.0-java)
+    eventmachine (1.0.4)
+    eventmachine (1.0.4-java)
     ffi2-generators (0.1.1)
     formatador (0.2.3)
     i18n (0.6.0)
@@ -257,7 +257,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   delorean
-  eventmachine
+  eventmachine (>= 1.0.4)
   excon!
   jruby-openssl
   open4

--- a/excon.gemspec
+++ b/excon.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   # s.add_development_dependency('DEVDEPNAME', [">= 1.1.0", "< 2.0.0"])
   s.add_development_dependency('activesupport')
   s.add_development_dependency('delorean')
-  s.add_development_dependency('eventmachine')
+  s.add_development_dependency('eventmachine', '>= 1.0.4')
   s.add_development_dependency('open4')
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')


### PR DESCRIPTION
See: https://github.com/eventmachine/eventmachine/issues/553

This should fix the "undeclared identifier" build errors in travis on ruby 2.2 with eventmachine 1.0.0.

@geemus please review