### PR TITLE
json 1.8.2 adds ruby 2.2 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,8 @@ GEM
     i18n (0.6.0)
     jruby-openssl (0.8.8)
       bouncy-castle-java (>= 1.5.0147)
-    json (1.7.3)
-    json (1.7.3-java)
+    json (1.8.2)
+    json (1.8.2-java)
     kgio (2.9.2)
     minitest (4.7.5)
     multi_json (1.3.6)
@@ -260,6 +260,7 @@ DEPENDENCIES
   eventmachine (>= 1.0.4)
   excon!
   jruby-openssl
+  json (>= 1.8.2)
   open4
   rack (~> 1.6)
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,8 @@ GEM
     chronic (0.6.7)
     delorean (2.0.0)
       chronic
-    eventmachine (1.0.0)
-    eventmachine (1.0.0-java)
+    eventmachine (1.0.4)
+    eventmachine (1.0.4-java)
     ffi2-generators (0.1.1)
     formatador (0.2.3)
     i18n (0.6.0)
@@ -257,7 +257,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   delorean
-  eventmachine
+  eventmachine (>= 1.0.4)
   excon!
   jruby-openssl
   open4

--- a/excon.gemspec
+++ b/excon.gemspec
@@ -62,6 +62,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc')
   s.add_development_dependency('shindo')
   s.add_development_dependency('sinatra')
+  s.add_development_dependency('json', '>= 1.8.2')
 
   ## Leave this section as-is. It will be automatically generated from the
   ## contents of your Git repository via the gemspec task. DO NOT REMOVE

--- a/excon.gemspec
+++ b/excon.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   # s.add_development_dependency('DEVDEPNAME', [">= 1.1.0", "< 2.0.0"])
   s.add_development_dependency('activesupport')
   s.add_development_dependency('delorean')
-  s.add_development_dependency('eventmachine')
+  s.add_development_dependency('eventmachine', '>= 1.0.4')
   s.add_development_dependency('open4')
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')


### PR DESCRIPTION
Excon depends on json via the rdoc dependency.  We need to add a direct
dependency on json since the rdoc dependency for json (~> 1.4) doesn't enforce 1.8.2.

See: https://github.com/flori/json/issues/229

This fixes "error: too few arguments provided to function-like macro invocation" I was seeing in the travis build failures on ruby 2.2.

Between this PR and #463, I was able to bundle and run the test suite on ruby 2.2

@geemus Please review!