### PR TITLE
custom uri parser to README + small fixes on Excon.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ connection = Excon.new('http://geemus.com/', :nonblock => false)
 connection = Excon.new('http://username:password@secure.geemus.com')
 connection = Excon.new('http://secure.geemus.com',
   :user => 'username', :password => 'password')
+
+# use custom uri parser
+require 'addressable/uri'
+connection = Excon.new('http://geemus.com/', uri_parser: Addressable::URI)
 ```
 
 ## Chunked Requests

--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -104,7 +104,7 @@ module Excon
     #   @param [Hash<Symbol, >] params One or more option params to set on the Connection instance
     #   @return [Connection] A new Excon::Connection instance
     def new(url, params = {})
-      uri_parser = params[:uri_parser] || Excon.defaults[:uri_parser]
+      uri_parser = params[:uri_parser] || defaults[:uri_parser]
       uri = uri_parser.parse(url)
       unless uri.scheme
         raise ArgumentError.new("Invalid URI: #{uri}")
@@ -116,7 +116,7 @@ module Excon
         :port       => uri.port,
         :query      => uri.query,
         :scheme     => uri.scheme
-      }.merge!(params)
+      }.merge(params)
       if uri.password
         params[:password] = Utils.unescape_uri(uri.password)
       end


### PR DESCRIPTION
1 ) Add example  to README -  ability for custom uri parser (#191)
```ruby
Excon.defaults[:uri_parser]
```
2 ) Excon as a namespace is not needed
m
3 ) bang method ```merge!``` is not needed.