### PR TITLE
Fixes #468 issue with frozen args in connection options

### DIFF
--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -56,7 +56,7 @@ module Excon
     # Splits a header value +str+ according to HTTP specification.
     def split_header_value(str)
       return [] if str.nil?
-      str = str.strip
+      str = str.dup.strip
       str.force_encoding('BINARY') if FORCE_ENC
       str.scan(%r'\G((?:"(?:\\.|[^"])+?"|[^",]+)+)
                     (?:,\s*|\Z)'xn).flatten
@@ -64,18 +64,21 @@ module Excon
 
     # Escapes HTTP reserved and unwise characters in +str+
     def escape_uri(str)
+      str = str.dup
       str.force_encoding('BINARY') if FORCE_ENC
       str.gsub(UNESCAPED) { "%%%02X" % $1[0].ord }
     end
 
     # Unescapes HTTP reserved and unwise characters in +str+
     def unescape_uri(str)
+      str = str.dup
       str.force_encoding('BINARY') if FORCE_ENC
       str.gsub(ESCAPED) { $1.hex.chr }
     end
 
     # Unescape form encoded values in +str+
     def unescape_form(str)
+      str = str.dup
       str.force_encoding('BINARY') if FORCE_ENC
       str.gsub!(/\+/, ' ')
       str.gsub(ESCAPED) { $1.hex.chr }

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -89,19 +89,27 @@ end
 Shindo.tests('Excon basics (Basic Auth Pass)') do
   with_rackup('basic_auth.ru') do
     basic_tests('http://test_user:test_password@127.0.0.1:9292')
+    tests('with frozen args').returns(200) do
+      user, pass, uri = ['test_user', 'test_password', 'http://127.0.0.1:9292'].map(&:freeze)
+      connection = Excon.new(uri, :user => user, :password => pass )
+      response = connection.request(:method => :get, :path => '/content-length/100')
+      response.status
+    end  
+  end
+end
 
-    tests('Excon basics (Basic Auth Fail)') do
-      cases = [
-        ['correct user, no password', 'http://test_user@127.0.0.1:9292'],
-        ['correct user, wrong password', 'http://test_user:fake_password@127.0.0.1:9292'],
-        ['wrong user, correct password', 'http://fake_user:test_password@127.0.0.1:9292'],
-      ]
-      cases.each do |desc,url|
-        tests("response.status for #{desc}").returns(401) do
-          connection = Excon.new(url)
-          response = connection.request(:method => :get, :path => '/content-length/100')
-          response.status
-        end
+Shindo.tests('Excon basics (Basic Auth Fail)') do
+  with_rackup('basic_auth.ru') do
+    cases = [
+      ['correct user, no password', 'http://test_user@127.0.0.1:9292'],
+      ['correct user, wrong password', 'http://test_user:fake_password@127.0.0.1:9292'],
+      ['wrong user, correct password', 'http://fake_user:test_password@127.0.0.1:9292']
+    ]
+    cases.each do |desc,url|
+      tests("response.status for #{desc}").returns(401) do
+        connection = Excon.new(url)
+        response = connection.request(:method => :get, :path => '/content-length/100')
+        response.status
       end
     end
   end


### PR DESCRIPTION
See #468 
Notes:
On current master(without my pull request) tests are failed, so travis may be fail:
```ruby
Excon basics (reusable local port)
    has a local port + returns true
    local port can be re-bound - returns "xxxxxxxxxx"
    Connection refused - connect(2) for 192.168.100.6:9292 (Errno::ECONNREFUSED)
      tests/basic_tests.rb:267:in `connect'
 ...
```