### PR TITLE
Don't send http request body on redirected request

### DIFF
--- a/lib/excon/middlewares/redirect_follower.rb
+++ b/lib/excon/middlewares/redirect_follower.rb
@@ -17,7 +17,11 @@ module Excon
             params = datum.dup
             params.delete(:stack)
             params.delete(:connection)
-            params[:method] = :get if [301, 302, 303].include? response[:status]
+            if [301, 302, 303].include?(response[:status])
+              params[:method] = :get
+              params.delete(:body)
+              params[:headers].delete('Content-Length')
+            end
             params[:headers] = datum[:headers].dup
             params[:headers].delete('Authorization')
             params[:headers].delete('Proxy-Connection')

--- a/tests/middlewares/redirect_follower_tests.rb
+++ b/tests/middlewares/redirect_follower_tests.rb
@@ -61,3 +61,20 @@ Shindo.tests('Excon redirect support for relative Location headers') do
 
   env_restore
 end
+
+Shindo.tests("Excon redirecting post request") do
+  env_init
+
+  with_rackup('redirecting.ru') do
+    tests("request not have content-length and body").returns('ok') do
+      Excon.post(
+        'http://127.0.0.1:9292',
+        :path         => '/first',
+        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
+        :body => "a=Some_content"
+      ).body
+    end
+  end
+
+  env_restore
+end

--- a/tests/rackups/redirecting.ru
+++ b/tests/rackups/redirecting.ru
@@ -1,0 +1,23 @@
+require 'sinatra'
+require 'json'
+require File.join(File.dirname(__FILE__), 'webrick_patch')
+
+class App < Sinatra::Base
+  set :environment, :production
+  enable :dump_errors
+
+  post('/first') do
+    redirect "/second"
+  end
+
+  get('/second') do
+    post_body = request.body.read
+    if post_body == "" && request["CONTENT_LENGTH"].nil?
+      "ok"
+    else
+      JSON.pretty_generate(request.env)
+    end
+  end
+end
+
+run App


### PR DESCRIPTION
We using squid and when POST request being redirected squid reject request (status code 411).

I find a problem in follow redirecting middleware, it should not send http body and header "Content-Length" when change to get request