### PR TITLE
Instrumentation: fix event namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ connection = Excon.new(
 )
 ```
 
-Excon will then instrument each request, retry, and error.  The corresponding events are named excon.request, excon.retry, and excon.error respectively.
+Excon will then instrument each request, retry, and error.  The corresponding events are named request.excon, retry.excon, and error.excon respectively.
 
 ```ruby
 ActiveSupport::Notifications.subscribe(/excon/) do |*args|
@@ -316,7 +316,7 @@ ActiveSupport::Notifications.subscribe(/excon/) do |*args|
 end
 ```
 
-If you prefer to label each event with something other than "excon," you may specify
+If you prefer to label each event with a namespace other than "excon," you may specify
 an alternate name in the constructor:
 
 ```ruby

--- a/lib/excon/middlewares/instrumentor.rb
+++ b/lib/excon/middlewares/instrumentor.rb
@@ -3,7 +3,7 @@ module Excon
     class Instrumentor < Excon::Middleware::Base
       def error_call(datum)
         if datum.has_key?(:instrumentor)
-          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.error", :error => datum[:error])
+          datum[:instrumentor].instrument("error.#{datum[:instrumentor_name]}", :error => datum[:error])
         end
         @stack.error_call(datum)
       end
@@ -11,9 +11,9 @@ module Excon
       def request_call(datum)
         if datum.has_key?(:instrumentor)
           if datum[:retries_remaining] < datum[:retry_limit]
-            event_name = "#{datum[:instrumentor_name]}.retry"
+            event_name = "retry.#{datum[:instrumentor_name]}"
           else
-            event_name = "#{datum[:instrumentor_name]}.request"
+            event_name = "request.#{datum[:instrumentor_name]}"
           end
           datum[:instrumentor].instrument(event_name, datum) do
             @stack.request_call(datum)
@@ -25,7 +25,7 @@ module Excon
 
       def response_call(datum)
         if datum.has_key?(:instrumentor)
-          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.response", datum[:response])
+          datum[:instrumentor].instrument("response.#{datum[:instrumentor_name]}", datum[:response])
         end
         @stack.response_call(datum)
       end


### PR DESCRIPTION
ActiveSupport::Notifications expects the namespace to be the suffix of the event name, not the prefix.

See [the source](https://github.com/rails/rails/blob/fcfca5c70023ab01388a87be49a4a33e29d6cd43/activesupport/lib/active_support/subscriber.rb#L67) and notice the pattern in the [Rails docs](http://edgeguides.rubyonrails.org/active_support_instrumentation.html)

Setting this properly allows the use of a `LogSubcriber` like this:

```ruby
Excon::LogSubscriber.attach_to :excon
```