### PR TITLE
Use our default config SSL config then ENV when available

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -30,10 +30,10 @@ module Excon
         # turn verification on
         ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
-        if ca_file = ENV['SSL_CERT_FILE'] || @data[:ssl_ca_file]
+        if ca_file = @data[:ssl_ca_file] || ENV['SSL_CERT_FILE']
           ssl_context.ca_file = ca_file
         end
-        if ca_path = ENV['SSL_CERT_DIR'] || @data[:ssl_ca_path]
+        if ca_path = @data[:ssl_ca_path] || ENV['SSL_CERT_DIR']
           ssl_context.ca_path = ca_path
         end
         if cert_store = @data[:ssl_cert_store]


### PR DESCRIPTION
This changes Excon to allow overriding SSL certs based on the config in the connection instead of defaulting to the ENV variable.

Google's [signet](https://github.com/google/signet/blob/master/lib/signet/ssl_config.rb) gem automatically sets these ENV variables, and it leads to unintuitive failures when you're using S2S and the signet gem overrides your config.
