### PR TITLE
Fix CPU spin wait on SSL connections

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -121,8 +121,9 @@ module Excon
               @socket.connect_nonblock
               break # connect succeeded
             rescue OpenSSL::SSL::SSLError => error
-              # would block, rescue and retry as select is non-helpful
               raise error unless error.message == 'read would block'
+              # Wait for socket status to change
+              IO.select([@socket.io],nil,[@socket.io])
             end
           end
         else


### PR DESCRIPTION
We were seeing excessive CPU consumption when initiating SSL connections on nonblocking sockets via Excon. When Excon creates an SSL connection on a non-blocking socket, it currently retries the connect call in a tight loop until the connection completes. This needlessly uses CPU cycles.

This patch inserts a IO.select call before it retries the connect thereby allowing the CPU to do useful work and only waking up the calling process when the connection completes (or errors).

This has been tested under heavy production workload and significantly reduces CPU consumption while working reliably.

NOTE: One could argue that the call should return a "read would block" error to Excon's caller, however, that would be a significant functionality change.  This patch keeps the behavior identical to current functionality but removes the CPU spin wait.