### PR TITLE
Fix scope of buffer in readline

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -40,8 +40,8 @@ module Excon
 
     def readline
       return legacy_readline if RUBY_VERSION.to_f <= 1.8_7
+      buffer = ''
       begin
-        buffer = ''
         buffer << @socket.read_nonblock(1) while buffer[-1] != "\n"
         buffer
       rescue Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable 


### PR DESCRIPTION
 Because buffer was declared within the scope of the begin/end block in readline(),  data read in initially would become lost to oblivion if a false-positive exception was raised and the block re-tried. This would result in lines like  "TTP/1.1 400 Bad Request\r\n", where H was at the start of the buffer, an exception was raised, and the block re-tried if it was a false positive, thus loosing the 'H'