### PR TITLE
Catch IO::WaitWritable for SSL sockets too

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -121,6 +121,9 @@ module Excon
           rescue IO::WaitReadable
             IO.select([@socket])
             retry
+          rescue IO::WaitWritable
+            IO.select(nil, [@socket])
+            retry
           end
         else
           @socket.connect


### PR DESCRIPTION
Most likely this is overkill. The original SSL code in Excon didn't catch this, but I found out Ruby docs do recommend it so being safe: http://ruby-doc.org/stdlib-1.9.3/libdoc/openssl/rdoc/OpenSSL/SSL/SSLSocket.html