### PR TITLE
SSLSocket "connect timeout reached" error may mask other errors

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -130,7 +130,7 @@ module Excon
         end
       rescue OpenSSL::SSL::SSLError
         raise
-      rescue
+      rescue Errno::ETIMEDOUT
         raise Excon::Errors::Timeout.new('connect timeout reached')
       end
 

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -130,7 +130,7 @@ module Excon
         end
       rescue OpenSSL::SSL::SSLError
         raise
-      rescue Errno::ETIMEDOUT
+      rescue Errno::ETIMEDOUT, Timeout::Error
         raise Excon::Errors::Timeout.new('connect timeout reached')
       end
 

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -128,8 +128,6 @@ module Excon
         else
           @socket.connect
         end
-      rescue OpenSSL::SSL::SSLError
-        raise
       rescue Errno::ETIMEDOUT, Timeout::Error
         raise Excon::Errors::Timeout.new('connect timeout reached')
       end


### PR DESCRIPTION
I'm worried that the [connection code](https://github.com/excon/excon/blob/master/lib/excon/ssl_socket.rb#L117-L135), may be masking other types of errors with a timeout error.

```ruby
      begin
        if @nonblock
          begin
            @socket.connect_nonblock
          rescue IO::WaitReadable
            IO.select([@socket])
            retry
          rescue IO::WaitWritable
            IO.select(nil, [@socket])
            retry
          end
        else
          @socket.connect
        end
      rescue OpenSSL::SSL::SSLError
        raise
      rescue
        raise Excon::Errors::Timeout.new('connect timeout reached')
      end
```
Is there something we could do here instead of always raising `Excon::Errors::Timeout`?