### PR TITLE
Ensure rackup starts server listening on all hosts for reusable port test

### DIFF
--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -94,7 +94,7 @@ Shindo.tests('Excon basics (Basic Auth Pass)') do
       connection = Excon.new(uri, :user => user, :password => pass )
       response = connection.request(:method => :get, :path => '/content-length/100')
       response.status
-    end  
+    end
   end
 end
 
@@ -285,7 +285,7 @@ Shindo.tests('Excon basics (reusable local port)') do
     end
   end
 
-  with_rackup('basic.ru') do
+  with_rackup('basic.ru', '0.0.0.0') do
     connection = Excon.new("http://127.0.0.1:9292/echo",
                            :reuseaddr => true, # enable address and port reuse
                            :persistent => true # keep the socket open

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -231,12 +231,12 @@ def rackup_path(*parts)
   File.expand_path(File.join(File.dirname(__FILE__), 'rackups', *parts))
 end
 
-def with_rackup(name)
+def with_rackup(name, host="127.0.0.1")
   unless RUBY_PLATFORM == 'java'
     GC.disable if RUBY_VERSION < '1.9'
-    pid, w, r, e = Open4.popen4("rackup", rackup_path(name))
+    pid, w, r, e = Open4.popen4("rackup", "--host", host, rackup_path(name))
   else
-    pid, w, r, e = IO.popen4("rackup", rackup_path(name))
+    pid, w, r, e = IO.popen4("rackup", "--host", host, rackup_path(name))
   end
   until e.gets =~ /HTTPServer#start:/; end
   yield


### PR DESCRIPTION
It appears that at some point rackup (or excon's use of rackup) changed so that webrick was no longer started listening on all interfaces. This lead to the server only listening on `localhost` which broke the `local port can be re-bound` test.

supposed rackup defaults:

```
$ rackup --help|grep host
  -o, --host HOST          listen on HOST (default: 0.0.0.0)
```

Fixes #497 