### PR TITLE
Add option to retain cookies through redirects

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@
 * Carl Hörberg <carl.hoerberg@gmail.com>
 * Carlos Sanchez <csanchez@maestrodev.com>
 * Claudio Poli <masterkain@gmail.com>
+* Colin Dean <colindean@us.ibm.com>
 * Damien Mathieu <damien@heroku.com>
 * Dan Hensgen <dan@methodhead.com>
 * Dan Peterson <dpiddy@gmail.com>

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     activesupport (3.2.6)
       i18n (~> 0.6)
       multi_json (~> 1.0)
+    backports (3.6.4)
     bouncy-castle-java (1.5.0147)
     chronic (0.6.7)
     delorean (2.0.0)
@@ -29,6 +30,8 @@ GEM
     rack (1.6.0)
     rack-protection (1.2.0)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     raindrops (0.13.0)
     rake (0.9.2.2)
     rdoc (3.12)
@@ -244,6 +247,13 @@ GEM
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
       tilt (~> 1.3, >= 1.3.3)
+    sinatra-contrib (1.3.2)
+      backports (>= 2.0)
+      eventmachine
+      rack-protection
+      rack-test
+      sinatra (~> 1.3.0)
+      tilt (~> 1.3)
     tilt (1.3.3)
     unicorn (4.8.3)
       kgio (~> 2.6)
@@ -268,4 +278,5 @@ DEPENDENCIES
   rubysl (~> 2.0)
   shindo
   sinatra
+  sinatra-contrib
   unicorn

--- a/excon.gemspec
+++ b/excon.gemspec
@@ -62,6 +62,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc')
   s.add_development_dependency('shindo')
   s.add_development_dependency('sinatra')
+  s.add_development_dependency('sinatra-contrib')
   s.add_development_dependency('json', '>= 1.8.2')
 
   ## Leave this section as-is. It will be automatically generated from the

--- a/lib/excon/middlewares/redirect_follower.rb
+++ b/lib/excon/middlewares/redirect_follower.rb
@@ -6,19 +6,23 @@ module Excon
         set_cookie.split(',').map { |full| full.split(';').first.strip }.join('; ')
       end
 
+      def get_header(datum, header)
+        _, header_value = datum[:response][:headers].detect do |key, value|
+          key.casecmp(header) == 0
+        end
+        header_value
+      end
+
       def response_call(datum)
         if datum.has_key?(:response)
           case datum[:response][:status]
           when 301, 302, 303, 307, 308
             uri_parser = datum[:uri_parser] || Excon.defaults[:uri_parser]
-            _, location = datum[:response][:headers].detect do |key, value|
-              key.casecmp('Location') == 0
-            end
+
+            location = get_header(datum, 'Location')
             uri = uri_parser.parse(location)
 
-            _, cookie = datum[:response][:headers].detect do |key, value|
-              key.casecmp('Set-Cookie') == 0
-            end
+            cookie = get_header(datum, 'Set-Cookie')
 
             cookie = extract_cookies_from_set_cookie(cookie) if cookie
 

--- a/tests/middlewares/redirect_follower_tests.rb
+++ b/tests/middlewares/redirect_follower_tests.rb
@@ -78,3 +78,20 @@ Shindo.tests("Excon redirecting post request") do
 
   env_restore
 end
+
+Shindo.tests("Excon redirecting with cookie preserved") do
+  env_init
+
+  with_rackup('redirecting_with_cookie.ru') do
+    tests('second request will send cookies set by the first').returns('ok') do
+      Excon.defaults[:redirect_with_cookies] = true
+      Excon.get(
+        'http://127.0.0.1:9292',
+        :path         => '/sets_cookie',
+        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
+      ).body
+    end
+  end
+
+  env_restore
+end

--- a/tests/middlewares/redirect_follower_tests.rb
+++ b/tests/middlewares/redirect_follower_tests.rb
@@ -88,7 +88,7 @@ Shindo.tests("Excon redirecting with cookie preserved") do
       Excon.get(
         'http://127.0.0.1:9292',
         :path         => '/sets_cookie',
-        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
+        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower]
       ).body
     end
 
@@ -96,7 +96,7 @@ Shindo.tests("Excon redirecting with cookie preserved") do
       Excon.get(
         'http://127.0.0.1:9292',
         :path         => '/sets_multi_cookie',
-        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
+        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower]
       ).body
     end
   end

--- a/tests/middlewares/redirect_follower_tests.rb
+++ b/tests/middlewares/redirect_follower_tests.rb
@@ -81,13 +81,21 @@ end
 
 Shindo.tests("Excon redirecting with cookie preserved") do
   env_init
+  Excon.defaults[:redirect_with_cookies] = true
 
   with_rackup('redirecting_with_cookie.ru') do
     tests('second request will send cookies set by the first').returns('ok') do
-      Excon.defaults[:redirect_with_cookies] = true
       Excon.get(
         'http://127.0.0.1:9292',
         :path         => '/sets_cookie',
+        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
+      ).body
+    end
+
+    tests('second request will send multiple cookies set by the first').returns('ok') do
+      Excon.get(
+        'http://127.0.0.1:9292',
+        :path         => '/sets_multi_cookie',
         :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
       ).body
     end

--- a/tests/middlewares/redirect_follower_tests.rb
+++ b/tests/middlewares/redirect_follower_tests.rb
@@ -101,5 +101,16 @@ Shindo.tests("Excon redirecting with cookie preserved") do
     end
   end
 
+  with_rackup('redirecting.ru') do
+    tests("runs normally when there are no cookies set").returns('ok') do
+      Excon.post(
+        'http://127.0.0.1:9292',
+        :path         => '/first',
+        :middlewares  => Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower],
+        :body => "a=Some_content"
+      ).body
+    end
+  end
+
   env_restore
 end

--- a/tests/rackups/redirecting_with_cookie.ru
+++ b/tests/rackups/redirecting_with_cookie.ru
@@ -21,6 +21,20 @@ class App < Sinatra::Base
       JSON.pretty_generate(headers)
     end
   end
+  
+  get('/sets_multi_cookie') do
+    cookies[:chocolatechip] = "chunky"
+    cookies[:thinmints] = "minty"
+    redirect "/requires_cookie"
+  end
+
+  get('/requires_cookie') do
+    if cookies[:chocolatechip] == "chunky" && cookies[:thinmints] == "minty" 
+      "ok"
+    else
+      JSON.pretty_generate(headers)
+    end
+  end
 end
 
 run App

--- a/tests/rackups/redirecting_with_cookie.ru
+++ b/tests/rackups/redirecting_with_cookie.ru
@@ -1,0 +1,26 @@
+require 'sinatra'
+require 'sinatra/cookies'
+require 'json'
+require File.join(File.dirname(__FILE__), 'webrick_patch')
+
+class App < Sinatra::Base
+  helpers Sinatra::Cookies
+  set :environment, :production
+  enable :dump_errors
+
+  get('/sets_cookie') do
+    cookies[:chocolatechip] = "chunky"
+    redirect "/requires_cookie"
+  end
+
+  get('/requires_cookie') do
+    cookie = cookies[:chocolatechip]
+    unless cookie.nil? || cookie != "chunky"
+      "ok"
+    else
+      JSON.pretty_generate(headers)
+    end
+  end
+end
+
+run App


### PR DESCRIPTION
I encountered a use case that necessitated passing cookies provided by the first URL to redirect URL. 

I've disabled this functionality by default in this PR.

See the commit messages for a little more history and discussion.
