### PR TITLE
Test that the query string can serialize an array as repeated query elements

### DIFF
--- a/tests/query_string_tests.rb
+++ b/tests/query_string_tests.rb
@@ -1,57 +1,68 @@
 Shindo.tests('Excon query string variants') do
   with_rackup('query_string.ru') do
-    connection = nil
+    connection = Excon.new('http://127.0.0.1:9292')
 
     tests(":query => {:foo => 'bar'}") do
+      response = connection.request(:method => :get, :path => '/query', :query => {:foo => 'bar'})
+      query_string = response.body[7..-1] # query string sent
+
       tests("query string sent").returns('foo=bar') do
-        connection = Excon.new('http://127.0.0.1:9292')
-
-        response = connection.request(:method => :get, :path => '/query', :query => {:foo => 'bar'})
-        query_string = response.body[7..-1] # query string sent
-
         query_string
       end
     end
 
     tests(":query => {:foo => nil}") do
-      tests("query string sent").returns('foo') do
-        response = connection.request(:method => :get, :path => '/query', :query => {:foo => nil})
-        query_string = response.body[7..-1] # query string sent
+      response = connection.request(:method => :get, :path => '/query', :query => {:foo => nil})
+      query_string = response.body[7..-1] # query string sent
 
+      tests("query string sent").returns('foo') do
         query_string
       end
     end
 
     tests(":query => {:foo => 'bar', :me => nil}") do
-      query_string = nil
+      response = connection.request(:method => :get, :path => '/query', :query => {:foo => 'bar', :me => nil})
+      query_string = response.body[7..-1] # query string sent
 
       test("query string sent includes 'foo=bar'") do
-        response = connection.request(:method => :get, :path => '/query', :query => {:foo => 'bar', :me => nil})
-        query_string = response.body[7..-1] # query string sent
-
         query_string.split('&').include?('foo=bar')
       end
 
       test("query string sent includes 'me'") do
         query_string.split('&').include?('me')
       end
-
     end
 
     tests(":query => {:foo => 'bar', :me => 'too'}") do
-      query_string = nil
+      response = connection.request(:method => :get, :path => '/query', :query => {:foo => 'bar', :me => 'too'})
+      query_string = response.body[7..-1] # query string sent
 
       test("query string sent includes 'foo=bar'") do
-        response = connection.request(:method => :get, :path => '/query', :query => {:foo => 'bar', :me => 'too'})
-        query_string = response.body[7..-1] # query string sent
-
         query_string.split('&').include?('foo=bar')
       end
 
       test("query string sent includes 'me=too'") do
         query_string.split('&').include?('me=too')
       end
+    end
 
+    # You can use an atom or a string for the hash keys, what is shown here is emulating
+    # the Rails and PHP style of serializing a query array with a square brackets suffix.
+    tests(":query => {'foo[]' => ['bar', 'baz'], :me => 'too'}") do
+      response = connection.request(:method => :get, :path => '/query', :query => {'foo[]' => ['bar', 'baz'], :me => 'too'})
+      query_string = response.body[7..-1] # query string sent
+
+      test("query string sent includes 'foo[]=bar'") do
+        query_string.split('&').include?('foo[]=bar')
+      end
+
+      test("query string sent includes 'foo[]=baz'") do
+        query_string.split('&').include?('foo[]=baz')
+      end
+
+      test("query string sent includes 'me=too'") do
+        query_string.split('&').include?('me=too')
+      end
     end
 
   end


### PR DESCRIPTION
Following up from #360, this test shows that an array is serialized as repeated query elements. To get the Rails / PHP array behavior, set the key to 'foo[]' => [ array elements ] to product the query string `?foo[]=bar&foo[]=baz`.