### PR TITLE
Allows SSL verification disabling via ENV var

### DIFF
--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -10,7 +10,7 @@ module Excon
 
       def initialize(socket_error=Excon::Errors::Error.new)
         if socket_error.message =~ /certificate verify failed/
-          super("Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs`, `ENV['SSL_CERT_DIR'] = path_to_certs`, `Excon.defaults[:ssl_ca_file] = path_to_file`, `ENV['SSL_CERT_FILE'] = path_to_file`, `Excon.defaults[:ssl_verify_callback] = callback` (see OpenSSL::SSL::SSLContext#verify_callback), or `Excon.defaults[:ssl_verify_peer] = false` (less secure).")
+          super("Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs`, `ENV['SSL_CERT_DIR'] = path_to_certs`, `Excon.defaults[:ssl_ca_file] = path_to_file`, `ENV['SSL_CERT_FILE'] = path_to_file`, `Excon.defaults[:ssl_verify_callback] = callback` (see OpenSSL::SSL::SSLContext#verify_callback), or `Excon.defaults[:ssl_verify_peer] = false` or `ENV['EXCON_SSL_VERIFY_PEER'] = 'false'` (less secure).")
         else
           super("#{socket_error.message} (#{socket_error.class})")
         end

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -4,6 +4,8 @@ module Excon
       OpenSSL::SSL::SSLSocket.public_method_defined?(m)
     end
 
+    VERIFY_ENV_VAR = 'EXCON_SSL_VERIFY_PEER'
+
     def initialize(data = {})
       super
 
@@ -26,7 +28,9 @@ module Excon
         ssl_context.ssl_version = @data[:ssl_version]
       end
 
-      if @data[:ssl_verify_peer]
+      env_verify_peer = ENV.has_key?(VERIFY_ENV_VAR) && (ENV[VERIFY_ENV_VAR] && ENV[VERIFY_ENV_VAR] != 'false')
+
+      if @data[:ssl_verify_peer] && env_verify_peer
         # turn verification on
         ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
@@ -133,7 +137,7 @@ module Excon
       end
 
       # verify connection
-      if @data[:ssl_verify_peer]
+      if @data[:ssl_verify_peer] && env_verify_peer
         @socket.post_connection_check(@data[:ssl_verify_peer_host] || @data[:host])
       end
 

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -135,6 +135,22 @@ Shindo.tests('Excon ssl verify peer (ssl)') do
 
       response.status
     end
+
+    tests('EXCON_SSL_VERIFY_PEER = "false" response.status').returns(200) do
+      ENV['EXCON_SSL_VERIFY_PEER'] = 'false'
+      connection = Excon.new('https://127.0.0.1:9443', :ssl_verify_peer => true )
+      response = connection.request(:method => :get, :path => '/content-length/100')
+
+      response.status
+    end
+
+    tests('EXCON_SSL_VERIFY_PEER = truthy GET /content-length/100').raises(Excon::Errors::SocketError) do
+      ENV['EXCON_SSL_VERIFY_PEER'] = 'foo'
+      connection = Excon.new('https://127.0.0.1:9443', :ssl_verify_peer => true )
+      response = connection.request(:method => :get, :path => '/content-length/100')
+
+      response.status
+    end
   end
 
   with_rackup('ssl_mismatched_cn.ru') do


### PR DESCRIPTION
Fixes #521.  Previously was possible to set certificates via environment
variables, but not possible to disable verification entirely.

I haven't used Shindo for writing tests before so glad to re-organize if there's a better way for these tests to be done.
