### PR TITLE
Decompress middleware should handle empty body.

### DIFF
--- a/tests/middlewares/decompress_tests.rb
+++ b/tests/middlewares/decompress_tests.rb
@@ -29,6 +29,11 @@ Shindo.tests('Excon Decompress Middleware') do
       tests('removes processed encoding from header').returns('') do
         resp[:headers]['Content-Encoding']
       end
+
+      tests('empty response body').returns('') do
+        resp = @connection.request(:body => '')
+        resp[:body]
+      end
     end
 
     tests('deflate') do

--- a/tests/servers/good.rb
+++ b/tests/servers/good.rb
@@ -55,9 +55,14 @@ module GoodServer
 
         case encoding
         when 'gzip'
-          io = (Zlib::GzipWriter.new(StringIO.new) << request[:body]).finish
-          io.rewind
-          body = io.read
+          body = request[:body]
+          if(body.nil? || body.empty?)
+            body = ''
+          else
+            io = (Zlib::GzipWriter.new(StringIO.new) << request[:body]).finish
+            io.rewind
+            body = io.read
+          end
         when 'deflate'
           # drops the zlib header
           deflator = Zlib::Deflate.new(nil, -Zlib::MAX_WBITS)


### PR DESCRIPTION
This fixes #533.