### PR TITLE
Query string keys should be escaped

### DIFF
--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -40,11 +40,12 @@ module Excon
       when Hash
         str << '?'
         datum[:query].sort_by {|k,_| k.to_s }.each do |key, values|
+          key = CGI.escape(key.to_s)
           if values.nil?
-            str << key.to_s << '&'
+            str << key << '&'
           else
             [values].flatten.each do |value|
-              str << key.to_s << '=' << CGI.escape(value.to_s) << '&'
+              str << key << '=' << CGI.escape(value.to_s) << '&'
             end
           end
         end

--- a/tests/query_string_tests.rb
+++ b/tests/query_string_tests.rb
@@ -52,16 +52,34 @@ Shindo.tests('Excon query string variants') do
       response = connection.request(:method => :get, :path => '/query', :query => {'foo[]' => ['bar', 'baz'], :me => 'too'})
       query_string = response.body[7..-1] # query string sent
 
-      test("query string sent includes 'foo[]=bar'") do
-        query_string.split('&').include?('foo[]=bar')
+      test("query string sent includes 'foo%5B%5D=bar'") do
+        query_string.split('&').include?('foo%5B%5D=bar')
       end
 
-      test("query string sent includes 'foo[]=baz'") do
-        query_string.split('&').include?('foo[]=baz')
+      test("query string sent includes 'foo%5B%5D=baz'") do
+        query_string.split('&').include?('foo%5B%5D=baz')
       end
 
       test("query string sent includes 'me=too'") do
         query_string.split('&').include?('me=too')
+      end
+    end
+
+    tests(":query => {'foo%=#' => 'bar%=#'}") do
+      response = connection.request(:method => :get, :path => '/query', :query => {'foo%=#' => 'bar%=#'})
+      query_string = response.body[7..-1] # query string sent
+
+      tests("query string sent").returns('foo%25%3D%23=bar%25%3D%23') do
+        query_string
+      end
+    end
+
+    tests(":query => {'foo%=#' => nil}") do
+      response = connection.request(:method => :get, :path => '/query', :query => {'foo%=#' => nil})
+      query_string = response.body[7..-1] # query string sent
+
+      tests("query string sent").returns('foo%25%3D%23') do
+        query_string
       end
     end
 


### PR DESCRIPTION
[RFC 3986 section 3.4](https://tools.ietf.org/html/rfc3986#section-3.4) only allows a limited set of characters to be used in the query component of a URI. The `query_string` method currently escapes values to meet this requirement, but does not escape keys. This means that the user of Excon would have to escape any disallowed characters in key names in the `Hash` passed in the `:query` option.

This pull request changes the `query_striing` method so that it escapes keys as well as values.