### PR TITLE
Fix basic auth passwords with special characters does not auth successfully

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -71,7 +71,7 @@ module Excon
 
       # Use Basic Auth if url contains a login
       if @data[:user] || @data[:password]
-        user, pass = Utils.unescape_form(@data[:user].to_s), Utils.unescape_form(@data[:password].to_s)
+        user, pass = @data[:user].to_s, @data[:password].to_s
         @data[:headers]['Authorization'] ||= 'Basic ' << ['' << user.to_s << ':' << pass.to_s].pack('m').delete(Excon::CR_NL)
       end
 

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -96,6 +96,14 @@ Shindo.tests('Excon basics (Basic Auth Pass)') do
       response.status
     end
   end
+
+  with_rackup('basic_auth_complex_password.ru') do
+    tests('with special characters in password').returns(200) do
+      connection = Excon.new('http://127.0.0.1:9292', :user => 'test_user', :password => 'test%FFpassword+plus' )
+      response = connection.request(:method => :get, :path => '/content-length/100')
+      response.status
+    end
+  end
 end
 
 Shindo.tests('Excon basics (Basic Auth Fail)') do

--- a/tests/rackups/basic_auth_complex_password.ru
+++ b/tests/rackups/basic_auth_complex_password.ru
@@ -1,0 +1,14 @@
+require File.join(File.dirname(__FILE__), 'basic')
+
+class BasicAuthComplexPassword < Basic
+  before do
+    auth ||= Rack::Auth::Basic::Request.new(request.env)
+    user, pass = auth.provided? && auth.basic? && auth.credentials
+    unless [user, pass] == ["test_user", "test%FFpassword+plus"]
+      response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
+      throw(:halt, [401, "Not authorized\n"])
+    end
+  end
+end
+
+run BasicAuth

--- a/tests/rackups/basic_auth_complex_password.ru
+++ b/tests/rackups/basic_auth_complex_password.ru
@@ -11,4 +11,4 @@ class BasicAuthComplexPassword < Basic
   end
 end
 
-run BasicAuth
+run BasicAuthComplexPassword


### PR DESCRIPTION
Attempt to fix #538.

Should you accept this PR, I think the same bug might also be lurking in the code path of `#setup_proxy` as well [here](https://github.com/excon/excon/blob/v0.45.4/lib/excon/connection.rb#L463).