### PR TITLE
add host/path/port to response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.1
   - 2.2
   - jruby
-  - rbx-2.2
+  - rbx-3.2
   - ree
 
 script: "bundle exec shindont"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ rvm:
   - ree
 
 script: "bundle exec shindont"
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: ruby
-
+matrix:
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: rbx-3.2
+    - rvm: ree
+  fast_finish: true
 rvm:
   - 1.8.7
   - 1.9.2
@@ -10,6 +15,5 @@ rvm:
   - jruby
   - rbx-3.2
   - ree
-
 script: "bundle exec shindont"
 sudo: false

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -16,17 +16,20 @@ module Excon
     def headers
       @data[:headers]
     end
-    def status=(new_status)
-      @data[:status] = new_status
+    def host
+      @data[:host]
     end
-    def status
-      @data[:status]
+    def local_address
+      @data[:local_address]
     end
-    def status_line
-      @data[:status_line]
+    def local_port
+      @data[:local_port]
     end
-    def status_line=(new_status_line)
-      @data[:status_line] = new_status_line
+    def path
+      @data[:path]
+    end
+    def port
+      @data[:port]
     end
     def reason_phrase=(new_reason_phrase)
       @data[:reason_phrase] = new_reason_phrase
@@ -40,11 +43,17 @@ module Excon
     def remote_ip
       @data[:remote_ip]
     end
-    def local_port
-      @data[:local_port]
+    def status=(new_status)
+      @data[:status] = new_status
     end
-    def local_address
-      @data[:local_address]
+    def status
+      @data[:status]
+    end
+    def status_line
+      @data[:status_line]
+    end
+    def status_line=(new_status_line)
+      @data[:status_line] = new_status_line
     end
 
     def self.parse(socket, datum)
@@ -57,7 +66,10 @@ module Excon
 
       datum[:response] = {
         :body          => '',
+        :host          => datum[:host],
         :headers       => Excon::Headers.new,
+        :path          => datum[:path],
+        :port          => datum[:port],
         :status        => status,
         :status_line   => line,
         :reason_phrase => reason_phrase


### PR DESCRIPTION
This provides a way to pull back more info from the response. Usually you wouldn't need this, but sometimes you might want to see where you ended up, ie after following redirects and it shouldn't hurt anything to add.

See also #527 