### PR TITLE
Always call instrumentor with a block

### DIFF
--- a/lib/excon/middlewares/instrumentor.rb
+++ b/lib/excon/middlewares/instrumentor.rb
@@ -3,9 +3,12 @@ module Excon
     class Instrumentor < Excon::Middleware::Base
       def error_call(datum)
         if datum.has_key?(:instrumentor)
-          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.error", :error => datum[:error])
+          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.error", :error => datum[:error]) do
+            @stack.error_call(datum)
+          end
+        else
+          @stack.error_call(datum)
         end
-        @stack.error_call(datum)
       end
 
       def request_call(datum)
@@ -25,9 +28,12 @@ module Excon
 
       def response_call(datum)
         if datum.has_key?(:instrumentor)
-          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.response", datum[:response])
+          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.response", datum[:response]) do
+            @stack.response_call(datum)
+          end
+        else
+          @stack.response_call(datum)
         end
-        @stack.response_call(datum)
       end
     end
   end


### PR DESCRIPTION
This changes the instrumentor implementation to pass a block with the
next middleware call in the case of `response_call` and `error_call`.

These calls in the instrumentor now match the `request_call` one.

This is needed to allow calculating the total time for the request.
Before this change the response_call instrumentor was called before the
middleware chain was called, meaning you could not include the time for
receiving and parsing the response in the total time for the call.

NB: If there are any instrumentors out that there that do *not* call the
block if passed in the case of response_call and error_call, the chain
*will* be halted and the response or error will not be handled normally.
I'm not sure if there is a good way around that (there is no way to
determine if the method takes a block (all methods can take a block)),
and some instrumentors *may* want to not call the block in certain
circumstances so ensuring the block always runs doesn't seem correct
either.