### PR TITLE
Make it possible for excon to support SSL for non-HTTPS URI schemes.

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -383,7 +383,7 @@ module Excon
       unix_proxy = @data[:proxy] ? @data[:proxy][:scheme] == UNIX : false
       sockets[@socket_key] ||= if @data[:scheme] == UNIX || unix_proxy
         Excon::UnixSocket.new(@data)
-      elsif @data[:scheme] == HTTPS
+      elsif @data[:ssl_uri_schemes].include?(@data[:scheme])
         Excon::SSLSocket.new(@data)
       else
         Excon::Socket.new(@data)

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -132,6 +132,7 @@ module Excon
     :read_timeout         => 60,
     :retry_limit          => DEFAULT_RETRY_LIMIT,
     :ssl_verify_peer      => true,
+    :ssl_uri_schemes      => [HTTPS],
     :tcp_nodelay          => false,
     :thread_safe_sockets  => true,
     :uri_parser           => URI,


### PR DESCRIPTION
Hi,

I'm working on a project that uses Excon middleware to implement a custom protocol that builds atop HTTP. It does _use_ HTTP under the hood, but there's a more complex sequence of operations that have to happen to access a resource. I ran into a bit of excitement trying to get SSL support working -- it's possible to do so by setting the `scheme` parameter to each Excon operation, though that somewhat defeats the purpose of doing a custom protocol implementation using middleware.

Anyhoo, the included patch makes it easy for middleware to do something like this:
```
module MyProtocolClient
  # Excon middleware for talking the MyProtocol protocol.
  class ExconMiddleware < Excon::Middleware::Base
    Excon::DEFAULTS[:middlewares] << self
    Excon::DEFAULTS[:ssl_uri_schemes] << 'my_scheme'

    #
    # BODY
    # OF
    # MIDDLEWARE
    #
  end
end
```
and have Excon use an SSL socket automatically.

Assuming this is OK with you...how should I go about testing this? All the current tests pass as-is, though I'm not sure where I ought to put any feature-specific tests in the current test suite.