### PR TITLE
Make stubs thread-local.

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -210,9 +210,9 @@ module Excon
       nil
     end
 
-    # get a list of defined stubs
+    # get a list of defined stubs for the current thread
     def stubs
-      @stubs ||= []
+      Thread.current[:_excon_stubs] ||= []
     end
 
     # remove first/oldest stub matching request_params


### PR DESCRIPTION
Simple tweak to make stubs local to the current thread. This allows for useful stubbing when running tests in parallel (as supported by Minitest).