### PR TITLE
Make certificate errors a unique class

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ connection = Excon.new('https://example.com',
 
 ## HTTPS/SSL Issues
 
-By default excon will try to verify peer certificates when using SSL for HTTPS. Unfortunately on some operating systems the defaults will not work. This will likely manifest itself as something like `Excon::Errors::SocketError: SSL_connect returned=1 ...`
+By default excon will try to verify peer certificates when using HTTPS. Unfortunately on some operating systems the defaults will not work. This will likely manifest itself as something like `Excon::Errors::CertificateError: SSL_connect returned=1 ...`
 
 If you have the misfortune of running into this problem you have a couple options. If you have certificates but they aren't being auto-discovered, you can specify the path to your certificates:
 

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -189,7 +189,7 @@ module Excon
         when Excon::Errors::StubNotFound, Excon::Errors::Timeout
           raise(error)
         else
-          raise(Excon::Errors::SocketError.new(error))
+          raise_socket_error(error)
         end
       end
 
@@ -392,7 +392,7 @@ module Excon
       when Excon::Errors::HTTPStatusError, Excon::Errors::Timeout
         raise(error)
       else
-        raise(Excon::Errors::SocketError.new(error))
+        raise_socket_error(error)
       end
     end
 
@@ -412,6 +412,14 @@ module Excon
         Thread.current[:_excon_sockets] ||= {}
       else
         @_excon_sockets ||= {}
+      end
+    end
+
+    def raise_socket_error(error)
+      if error.message =~ /certificate verify failed/
+        raise(Excon::Errors::CertificateError.new(error))
+      else
+        raise(Excon::Errors::SocketError.new(error))
       end
     end
 

--- a/lib/excon/errors.rb
+++ b/lib/excon/errors.rb
@@ -8,12 +8,29 @@ module Excon
     class SocketError < Error
       attr_reader :socket_error
 
-      def initialize(socket_error=Excon::Errors::Error.new)
-        if socket_error.message =~ /certificate verify failed/
-          super("Unable to verify certificate, please set `Excon.defaults[:ssl_ca_path] = path_to_certs`, `ENV['SSL_CERT_DIR'] = path_to_certs`, `Excon.defaults[:ssl_ca_file] = path_to_file`, `ENV['SSL_CERT_FILE'] = path_to_file`, `Excon.defaults[:ssl_verify_callback] = callback` (see OpenSSL::SSL::SSLContext#verify_callback), or `Excon.defaults[:ssl_verify_peer] = false` (less secure).")
+      def initialize(socket_error = Excon::Errors::Error.new)
+        if is_a?(CertificateError)
+          super
         else
           super("#{socket_error.message} (#{socket_error.class})")
+          set_backtrace(socket_error.backtrace)
+          @socket_error = socket_error
         end
+      end
+    end
+
+    class CertificateError < SocketError
+      def initialize(socket_error = Excon::Errors::Error.new)
+        msg = "Unable to verify certificate. This may be an issue with the remote host or with Excon." +
+              "Excon has certificates bundled, but these can be customized." +
+              "`Excon.defaults[:ssl_ca_path] = path_to_certs`, " +
+              "`ENV['SSL_CERT_DIR'] = path_to_certs`, " +
+              "`Excon.defaults[:ssl_ca_file] = path_to_file`, " +
+              "`ENV['SSL_CERT_FILE'] = path_to_file`, " +
+              "`Excon.defaults[:ssl_verify_callback] = callback` (see OpenSSL::SSL::SSLContext#verify_callback), or " +
+              "`Excon.defaults[:ssl_verify_peer] = false` (less secure)."
+        full_message = "#{socket_error.message} (#{socket_error.class})" + ' ' + msg
+        super(full_message)
         set_backtrace(socket_error.backtrace)
         @socket_error = socket_error
       end


### PR DESCRIPTION
@geemus  I've put together a suggestion for how to break certificate errors into its own class. Thoughts, good/bad? :)

A few questions:
- Why do you store the `socket_error` on the error instance? I don't see it being used anywhere.
- And related, why is there a plain error as the default param for the socket error instance? From what I can tell it's always called with an error instance as the first argument (both in tests and in connection.rb).

Please enlighten me, I'm sure there are good reasons to the above, that I haven't grasped.

Related to https://github.com/excon/excon/issues/513