### PR TITLE
add option to use global stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ config.before(:all) do
 end
 ```
 
+By default stubs are shared globally, to make stubs unique to each thread, use `Excon.defaults[:stubs] = :local`.
+
 ## Instrumentation
 
 Excon calls can be timed using the [ActiveSupport::Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) API.

--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -210,9 +210,14 @@ module Excon
       nil
     end
 
-    # get a list of defined stubs for the current thread
+    # get a list of defined stubs
     def stubs
-      Thread.current[:_excon_stubs] ||= []
+      case Excon.defaults[:stubs]
+      when :global
+        @stubs ||= []
+      else
+        Thread.current[:_excon_stubs] ||= []
+      end
     end
 
     # remove first/oldest stub matching request_params

--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -215,7 +215,7 @@ module Excon
       case Excon.defaults[:stubs]
       when :global
         @stubs ||= []
-      else
+      when :local
         Thread.current[:_excon_stubs] ||= []
       end
     end

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -133,6 +133,7 @@ module Excon
     :retry_limit          => DEFAULT_RETRY_LIMIT,
     :ssl_verify_peer      => true,
     :ssl_uri_schemes      => [HTTPS],
+    :stubs                => :global,
     :tcp_nodelay          => false,
     :thread_safe_sockets  => true,
     :uri_parser           => URI,

--- a/tests/middlewares/mock_tests.rb
+++ b/tests/middlewares/mock_tests.rb
@@ -253,9 +253,6 @@ Shindo.tests('Excon stubs') do
   end
 
   tests("global stubs") do
-    original_stubs_value = Excon.defaults[:stubs]
-    Excon.defaults[:stubs] = :global
-
     connection = Excon.new('http://127.0.0.1:9292', :mock => true)
     Excon.stub({}, {:body => '1'})
     t = Thread.new do
@@ -269,11 +266,12 @@ Shindo.tests('Excon stubs') do
       connection.request(:method => :get).body
     end
     Excon.stubs.clear
-
-    Excon.defaults[:stubs] = original_stubs_value
   end
 
   tests("thread-local stubs") do
+    original_stubs_value = Excon.defaults[:stubs]
+    Excon.defaults[:stubs] = :local
+
     connection = Excon.new('http://127.0.0.1:9292', :mock => true)
     Excon.stub({}, {:body => '1'})
     t = Thread.new do
@@ -287,6 +285,8 @@ Shindo.tests('Excon stubs') do
       connection.request(:method => :get).body
     end
     Excon.stubs.clear
+
+    Excon.defaults[:stubs] = original_stubs_value
   end
 
   env_restore

--- a/tests/middlewares/mock_tests.rb
+++ b/tests/middlewares/mock_tests.rb
@@ -262,11 +262,11 @@ Shindo.tests('Excon stubs') do
       Excon.stub({}, {:body => '2'})
       connection.request(:method => :get).body
     end
-    tests("get on main thread").returns('2') do
-      connection.request(:method => :get).body
-    end
     tests("get on a different thread").returns('2') do
       t.join.value
+    end
+    tests("get on main thread").returns('2') do
+      connection.request(:method => :get).body
     end
     Excon.stubs.clear
 
@@ -280,11 +280,11 @@ Shindo.tests('Excon stubs') do
       Excon.stub({}, {:body => '2'})
       connection.request(:method => :get).body
     end
-    tests("get on main thread").returns('1') do
-      connection.request(:method => :get).body
-    end
     tests("get on a different thread").returns('2') do
       t.join.value
+    end
+    tests("get on main thread").returns('1') do
+      connection.request(:method => :get).body
     end
     Excon.stubs.clear
   end


### PR DESCRIPTION
You can set the option via `Excon.defaults[:stubs] = :global`.