### PR TITLE
Add "Plugins and Middlewares" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ Excon was designed to be simple, fast and performant. It works great as a genera
 [![Gem Version](https://badge.fury.io/rb/excon.svg)](http://badge.fury.io/rb/excon)
 [![Gittip](http://img.shields.io/gittip/geemus.svg)](https://www.gittip.com/geemus/)
 
+* [Getting Started](#getting-started)
+* [Options](#options)
+* [Chunked Requests](#chunked-requests)
+* [Pipelining Requests](#pipelining-requests)
+* [Streaming Responses](#streaming-responses)
+* [Proxy Support](#proxy-support)
+* [Reusable ports](#reusable-ports)
+* [Unix Socket Support](#unix-socket-support)
+* [Stubs](#stubs)
+* [Instrumentation](#instrumentation)
+* [HTTPS client certificate](#https-client-certificate)
+* [HTTPS/SSL Issues](#httpsssl-issues)
+* [Getting Help](#getting-help)
+* [Contributing](#contributing)
+* [Plugins and Middlewares](#plugins-and-middlewares)
+* [License](#license)
+
 ## Getting Started
 
 Install the gem.

--- a/README.md
+++ b/README.md
@@ -417,6 +417,27 @@ Either of these should allow you to work around the socket error and continue wi
 
 Please refer to [CONTRIBUTING.md](https://github.com/excon/excon/blob/master/CONTRIBUTING.md).
 
+# Plugins and Middlewares
+
+Using Excon's [Middleware system][middleware], you can easily extend Excon's
+functionality with your own. The following plugins extend Excon in their own
+way:
+
+* [excon-addressable](https://github.com/JeanMertz/excon-addressable)
+
+  Set [addressable](https://github.com/sporkmonger/addressable) as the default
+  URI parser, and add support for [URI templating][templating].
+
+* [excon-hypermedia](https://github.com/JeanMertz/excon-hypermedia)
+
+  Teaches Excon to talk with [HyperMedia APIs][hypermedia]. Allowing you to use
+  all of Excon's functionality, while traversing APIs in an easy and
+  self-discovering way.
+
 ## License
 
 Please refer to [LICENSE.md](https://github.com/excon/excon/blob/master/LICENSE.md).
+
+[middleware]: lib/excon/middlewares/base.rb
+[hypermedia]: https://en.wikipedia.org/wiki/HATEOAS
+[templating]: https://www.rfc-editor.org/rfc/rfc6570.txt


### PR DESCRIPTION
This helps people find interesting tools built on top of Excon. See https://github.com/excon/excon/issues/567#issuecomment-220410188

I also added a TOC, as the README was becoming quite long. I can revert this, if you think it shouldn't be included.