### PR TITLE
optionally allow unstubbed requests to go through

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ Excon.stub({}, lambda {|request_params| {:body => request_params[:body], :status
 
 Omitted attributes are assumed to match, so this stub will match *any* request and return an Excon::Response with a body of 'body' and status of 200.  You can add whatever stubs you might like this way and they will be checked against in the order they were added, if none of them match then excon will raise an `Excon::Errors::StubNotFound` error to let you know.
 
+If you want to allow unstubbed requests without raising `StubNotFound`, set the `allow_unstubbed_requests` option either globally or per request.
+
+```ruby
+connection = Excon.new('http://example.com', :mock => true, :allow_unstubbed_requests => true)
+```
+
 To remove a previously defined stub, or all stubs:
 
 ```ruby

--- a/lib/excon/middlewares/mock.rb
+++ b/lib/excon/middlewares/mock.rb
@@ -35,7 +35,7 @@ module Excon
             if stub_datum.has_key?(:headers)
               datum[:response][:headers].merge!(stub_datum[:headers])
             end
-          else
+          elsif datum[:allow_unstubbed_requests] != true
             # if we reach here no stubs matched
             message = StringIO.new
             message.puts('no stubs matched')

--- a/tests/middlewares/mock_tests.rb
+++ b/tests/middlewares/mock_tests.rb
@@ -153,6 +153,17 @@ Shindo.tests('Excon stubs') do
     Excon.get('http://127.0.0.1:9292/', :mock => true)
   end
 
+  with_server('good') do
+    tests('allow mismatched stub').returns(200) do
+      Excon.stub({:path => '/echo/request_count'}, {:body => 'body'})
+      Excon.get(
+        'http://127.0.0.1:9292/echo/request',
+        :mock => true,
+        :allow_unstubbed_requests => true
+      ).status
+    end
+  end
+
   Excon.stubs.clear
 
   tests("stub({}, {:body => 'x' * (Excon::DEFAULT_CHUNK_SIZE + 1)})") do


### PR DESCRIPTION
I've got a use-case where I want to stub requests, but don't want to block non-stubbed requests from going through.

This is basically the same as VCR's `allow_http_connections_when_no_cassette`, or Webmock's `allow_net_connect!`.

```ruby
Excon.get('http://example.com', :mock => true, :allow_unstubbed_requests => true)
```