### PR TITLE
Alias Errors::Error to Error vs defining new class which inherits

### DIFF
--- a/lib/excon/error.rb
+++ b/lib/excon/error.rb
@@ -182,7 +182,7 @@ or:
 
   # Legacy
   module Errors
-    class Error < Excon::Error; end
+    Excon::Errors::Error = Excon::Error
 
     legacy_re = /
       \A

--- a/tests/error_tests.rb
+++ b/tests/error_tests.rb
@@ -55,6 +55,14 @@ Shindo.tests('HTTPStatusError request/response debugging') do
     end
   end
 
+  tests('can raise standard error and catch legacy errors').returns(true) do
+    begin
+      raise Excon::Error::NotFound.new('bar')
+    rescue Excon::Errors::Error => e
+      true
+    end
+  end
+
   tests('can raise with status_error() and catch with standard error').returns(true) do
     begin
       raise Excon::Error.status_error({expects: 200}, {status: 400})


### PR DESCRIPTION
Fixes https://github.com/excon/excon/issues/579 and https://github.com/excon/excon/issues/580