### PR TITLE
Support for frozen string literals

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
@@ -55,7 +56,7 @@ module Excon
     def display_warning(warning)
       # Show warning if $VERBOSE or ENV['EXCON_DEBUG'] is set
       if $VERBOSE || ENV['EXCON_DEBUG']
-        $stderr.puts '[excon][WARNING] ' << warning << "\n#{ caller.join("\n") }"
+        $stderr.puts "[excon][WARNING] #{warning}\n#{ caller.join("\n") }"
       end
     end
 
@@ -149,7 +150,7 @@ module Excon
         if uri.user || uri.password
           request_params[:headers] ||= {}
           user, pass = Utils.unescape_form(uri.user.to_s), Utils.unescape_form(uri.password.to_s)
-          request_params[:headers]['Authorization'] ||= 'Basic ' << ['' << user << ':' << pass].pack('m').delete(Excon::CR_NL)
+          request_params[:headers]['Authorization'] ||= 'Basic ' + ["#{user}:#{pass}"].pack('m').delete(Excon::CR_NL)
         end
       end
       if request_params.has_key?(:headers)

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -76,7 +76,6 @@ module Excon
         @data[:headers]['Authorization'] ||= 'Basic ' + ["#{user}:#{pass}"].pack('m').delete(Excon::CR_NL)
       end
 
-      @socket_key = @data[:scheme].dup
       if @data[:scheme] == UNIX
         if @data[:host]
           raise ArgumentError, "The `:host` parameter should not be set for `unix://` connections.\n" +
@@ -84,10 +83,10 @@ module Excon
         elsif !@data[:socket]
           raise ArgumentError, 'You must provide a `:socket` for `unix://` connections'
         else
-          @socket_key = @socket_key + '://' + @data[:socket]
+          @socket_key = "#{@data[:scheme]}://#{@data[:socket]}"
         end
       else
-        @socket_key = @socket_key + '://' + @data[:host] + port_string(@data)
+        @socket_key = "#{@data[:scheme]}://#{@data[:host]}#{port_string(@data)}"
       end
       reset
     end

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -30,9 +30,9 @@ module Excon
 
   UNIX = 'unix'
 
-  USER_AGENT = 'excon/' + VERSION
+  USER_AGENT = "excon/#{VERSION}"
 
-  VERSIONS = USER_AGENT + ' (' + RUBY_PLATFORM + ') ruby/' + RUBY_VERSION
+  VERSIONS = "#{USER_AGENT} (#{RUBY_PLATFORM}) ruby/#{RUBY_VERSION}"
 
   VALID_REQUEST_KEYS = [
     :body,

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
 
   VERSION = '0.51.0'
@@ -29,9 +30,9 @@ module Excon
 
   UNIX = 'unix'
 
-  USER_AGENT = 'excon/' << VERSION
+  USER_AGENT = 'excon/' + VERSION
 
-  VERSIONS = USER_AGENT + ' (' << RUBY_PLATFORM << ') ruby/' << RUBY_VERSION
+  VERSIONS = USER_AGENT + ' (' + RUBY_PLATFORM + ') ruby/' + RUBY_VERSION
 
   VALID_REQUEST_KEYS = [
     :body,

--- a/lib/excon/error.rb
+++ b/lib/excon/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   # Excon exception classes
   class Error < StandardError
@@ -36,8 +37,8 @@ Unable to verify certificate. This may be an issue with the remote host or with 
 or:
             `Excon.defaults[:ssl_verify_peer] = false` (less secure).
         EOL
-        full_message = "#{socket_error.message} (#{socket_error.class})"
-        full_message << ' ' + msg
+        full_message = "#{socket_error.message} (#{socket_error.class})" +
+                       ' ' + msg
         super(full_message)
         set_backtrace(socket_error.backtrace)
         @socket_error = socket_error
@@ -163,8 +164,8 @@ or:
         error_class, error_message = [default_class, 'Unknown']
       end
       message = StringIO.new
-      str = "Expected(#{request[:expects].inspect}) <=>"
-      str << " Actual(#{response[:status]} #{error_message})"
+      str = "Expected(#{request[:expects].inspect}) <=>" +
+            " Actual(#{response[:status]} #{error_message})"
       message.puts(str)
       if request[:debug_request]
         message.puts('excon.error.request')
@@ -201,7 +202,7 @@ or:
 
     klasses.each do |klass|
       class_name = klass.to_s
-      unless class_name =~ /Error\Z/ 
+      unless class_name =~ /Error\Z/
         class_name = klass.to_s + 'Error' if class_name =~ legacy_re
       end
       Excon::Errors.const_set(class_name, Excon::Error.const_get(klass))

--- a/lib/excon/extensions/uri.rb
+++ b/lib/excon/extensions/uri.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # TODO: Remove this monkey patch once ruby 1.9.3+ is the minimum supported version.
 #
 # This patch backports URI#hostname to ruby 1.9.2 and older.

--- a/lib/excon/headers.rb
+++ b/lib/excon/headers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   class Headers < Hash
 

--- a/lib/excon/middlewares/base.rb
+++ b/lib/excon/middlewares/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class Base

--- a/lib/excon/middlewares/capture_cookies.rb
+++ b/lib/excon/middlewares/capture_cookies.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class CaptureCookies < Excon::Middleware::Base

--- a/lib/excon/middlewares/decompress.rb
+++ b/lib/excon/middlewares/decompress.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class Decompress < Excon::Middleware::Base

--- a/lib/excon/middlewares/escape_path.rb
+++ b/lib/excon/middlewares/escape_path.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class EscapePath < Excon::Middleware::Base

--- a/lib/excon/middlewares/expects.rb
+++ b/lib/excon/middlewares/expects.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class Expects < Excon::Middleware::Base

--- a/lib/excon/middlewares/idempotent.rb
+++ b/lib/excon/middlewares/idempotent.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class Idempotent < Excon::Middleware::Base

--- a/lib/excon/middlewares/instrumentor.rb
+++ b/lib/excon/middlewares/instrumentor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class Instrumentor < Excon::Middleware::Base

--- a/lib/excon/middlewares/mock.rb
+++ b/lib/excon/middlewares/mock.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class Mock < Excon::Middleware::Base

--- a/lib/excon/middlewares/redirect_follower.rb
+++ b/lib/excon/middlewares/redirect_follower.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class RedirectFollower < Excon::Middleware::Base

--- a/lib/excon/middlewares/response_parser.rb
+++ b/lib/excon/middlewares/response_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Middleware
     class ResponseParser < Excon::Middleware::Base

--- a/lib/excon/pretty_printer.rb
+++ b/lib/excon/pretty_printer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   class PrettyPrinter
     def self.pp(io, datum, indent=0)

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   class Response
 
@@ -65,7 +66,7 @@ module Excon
       reason_phrase = line[13..-3] # -3 strips the trailing "\r\n"
 
       datum[:response] = {
-        :body          => '',
+        :body          => String.new,
         :cookies       => [],
         :host          => datum[:host],
         :headers       => Excon::Headers.new,

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   class Socket
     include Utils
@@ -23,7 +24,7 @@ module Excon
     def initialize(data = {})
       @data = data
       @nonblock = data[:nonblock]
-      @read_buffer = ''
+      @read_buffer = String.new
       @eof = false
       connect
     end
@@ -40,7 +41,7 @@ module Excon
 
     def readline
       return legacy_readline if RUBY_VERSION.to_f <= 1.8_7
-      buffer = ''
+      buffer = String.new
       begin
         buffer << @socket.read_nonblock(1) while buffer[-1] != "\n"
         buffer

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   class SSLSocket < Socket
     HAVE_NONBLOCK = [:connect_nonblock, :read_nonblock, :write_nonblock].all? do |m|
@@ -47,7 +48,7 @@ module Excon
 
           # workaround issue #257 (JRUBY-6970)
           ca_file = DEFAULT_CA_FILE
-          ca_file.gsub!(/^jar:/, '') if ca_file =~ /^jar:file:\//
+          ca_file = ca_file.gsub(/^jar:/, '') if ca_file =~ /^jar:file:\//
 
           begin
             ssl_context.cert_store.add_file(ca_file)
@@ -86,17 +87,17 @@ module Excon
       end
 
       if @data[:proxy]
-        request = 'CONNECT ' << @data[:host] << port_string(@data.merge(:omit_default_port => false)) << Excon::HTTP_1_1
-        request << 'Host: ' << @data[:host] << port_string(@data) << Excon::CR_NL
+        request = "CONNECT #{@data[:host]}#{port_string(@data.merge(:omit_default_port => false))}#{Excon::HTTP_1_1}" +
+                  "Host: #{@data[:host]}#{port_string(@data)}#{Excon::CR_NL}"
 
         if @data[:proxy][:password] || @data[:proxy][:user]
-          auth = ['' << @data[:proxy][:user].to_s << ':' << @data[:proxy][:password].to_s].pack('m').delete(Excon::CR_NL)
-          request << 'Proxy-Authorization: Basic ' << auth << Excon::CR_NL
+          auth = ["#{@data[:proxy][:user]}:#{@data[:proxy][:password]}"].pack('m').delete(Excon::CR_NL)
+          request += "Proxy-Authorization: Basic #{auth}#{Excon::CR_NL}"
         end
 
-        request << 'Proxy-Connection: Keep-Alive' << Excon::CR_NL
+        request += "Proxy-Connection: Keep-Alive#{Excon::CR_NL}"
 
-        request << Excon::CR_NL
+        request += Excon::CR_NL
 
         # write out the proxy setup request
         @socket.write(request)

--- a/lib/excon/standard_instrumentor.rb
+++ b/lib/excon/standard_instrumentor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   class StandardInstrumentor
     def self.instrument(name, params = {}, &block)

--- a/lib/excon/unix_socket.rb
+++ b/lib/excon/unix_socket.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   class UnixSocket < Excon::Socket
 

--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Excon
   module Utils
     extend self
@@ -14,26 +15,26 @@ module Excon
         raise ArgumentError, '`datum` must be given unless called on a Connection'
       end
       if datum[:scheme] == UNIX
-        '' << datum[:scheme] << '://' << datum[:socket]
+        "#{datum[:scheme]}://#{datum[:socket]}"
       else
-        '' << datum[:scheme] << '://' << datum[:host] << port_string(datum)
+        "#{datum[:scheme]}://#{datum[:host]}#{port_string(datum)}"
       end
     end
 
     def request_uri(datum)
-      connection_uri(datum) << datum[:path] << query_string(datum)
+      connection_uri(datum) + datum[:path] + query_string(datum)
     end
 
     def port_string(datum)
       if datum[:port].nil? || (datum[:omit_default_port] && ((datum[:scheme].casecmp('http') == 0 && datum[:port] == 80) || (datum[:scheme].casecmp('https') == 0 && datum[:port] == 443)))
         ''
       else
-        ':' << datum[:port].to_s
+        ':' + datum[:port].to_s
       end
     end
 
     def query_string(datum)
-      str = ''
+      str = String.new
       case datum[:query]
       when String
         str << '?' << datum[:query]


### PR DESCRIPTION
In Ruby 3.0 string literals will be frozen by default. This commit adds
the `# frozen_string_literal: true` magic comment to all `lib` files,
emulating that behavior.

Most `<<` operators where changed by string interpolation or `+`, this
should present little to no performance impact.

Tests and specs were intentionally not changed, as they are being rewritten to use rspec, and seemed like it may be better to change it while moving it. This commit tries to do the minimum to start supporting frozen strings.

From: https://github.com/excon/excon/issues/585