### PR TITLE
Update concat vs interpolation benchmark

### DIFF
--- a/benchmarks/concat_vs_interpolate.rb
+++ b/benchmarks/concat_vs_interpolate.rb
@@ -5,17 +5,18 @@ key = 'Content-Length'
 value = '100'
 Tach.meter(1_000) do
   tach('concat') do
-    key << ': ' << value << "\r\n"
+    temp = ''
+    temp << key << ': ' << value << "\r\n"
   end
   tach('interpolate') do
-    "#{key}: value\r\n"
+    "#{key}: #{value}\r\n"
   end
 end
 
 # +-------------+----------+
 # | tach        | total    |
 # +-------------+----------+
-# | concat      | 0.000902 |
+# | interpolate | 0.000404 |
 # +-------------+----------+
-# | interpolate | 0.019667 |
+# | concat      | 0.000564 |
 # +-------------+----------+


### PR DESCRIPTION
There was a subtle bug in the benchmark where key actually grows in
size every iteration, so it became "Content-Leght: : 100\r\n" the first
iteration, then "Content-Leght: : 100\r\nContent-Leght: : 100\r\n" the
second one, and so on. While interpolation is creating new strings every
time.
To make it a bit more fair,  temporary variable was created.

Also, in the interpolation part, `value` was not being interpolated.

Benchmark numbers were updated as well.