### PR TITLE
Allow individual requests to provide a user and password

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -223,6 +223,11 @@ module Excon
       datum = @data.merge(params)
       datum[:headers] = @data[:headers].merge(datum[:headers] || {})
 
+      if datum[:user] || datum[:password]
+        user, pass = Utils.unescape_form(datum[:user].to_s), Utils.unescape_form(datum[:password].to_s)
+        datum[:headers]['Authorization'] ||= 'Basic ' + ["#{user}:#{pass}"].pack('m').delete(Excon::CR_NL)
+      end
+
       if datum[:scheme] == UNIX
         datum[:headers]['Host']   = ''
       else

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -91,10 +91,17 @@ end
 Shindo.tests('Excon basics (Basic Auth Pass)') do
   with_rackup('basic_auth.ru') do
     basic_tests('http://test_user:test_password@127.0.0.1:9292')
+
     tests('with frozen args').returns(200) do
       user, pass, uri = ['test_user', 'test_password', 'http://127.0.0.1:9292'].map(&:freeze)
       connection = Excon.new(uri, :user => user, :password => pass )
       response = connection.request(:method => :get, :path => '/content-length/100')
+      response.status
+    end
+
+    tests('with persistent connection').returns(200) do
+      connection = Excon.new('http://127.0.0.1:9292', :persistent => true, :method => :get, :path => '/content-length/100')
+      response = connection.request(user: 'test_user', password: 'test_password')
       response.status
     end
   end


### PR DESCRIPTION
Allow individual requests to provide a user and password by recreating the ``Authorization`` if ``user`` and ``password`` are passed.

This will fix #588.