### PR TITLE
First pass at allowing SSL assets to be already loaded. #597

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,20 @@ connection = Excon.new('https://example.com',
 
 `client_key_pass` is optional.
 
+If you already have loaded the certificate and key into memory, then pass it through like:
+
+```ruby
+client_cert_data = File.load 'mycert.pem'
+client_key_data = File.load 'mycert.key'
+
+connection = Excon.new('https://example.com',
+                       client_cert_data: client_cert_data,
+                       client_key_data: client_key_data)
+```
+
+This can be useful if your program has already loaded the assets through
+another mechanism (E.g. a remote API call to a secure K:V system like Vault).
+
 ## HTTPS/SSL Issues
 
 By default excon will try to verify peer certificates when using HTTPS. Unfortunately on some operating systems the defaults will not work. This will likely manifest itself as something like `Excon::Errors::CertificateError: SSL_connect returned=1 ...`

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -66,16 +66,22 @@ module Excon
       end
 
       # maintain existing API
-      certificate_data = @data[:client_cert] || @data[:certificate_path]
-      private_key_data = @data[:client_key] || @data[:private_key_path]
+      client_cert_data = if cert_data = @data[:client_cert_data]
+                           cert_data
+                         elsif path = (@data[:client_cert] || @data[:certificate_path])
+                           File.read path
+                         end
+
+      private_key_data = if key_data = @data[:private_key_data]
+                           key_data
+                         elsif path = (@data[:client_key] || @data[:private_key_path])
+                           File.read path
+                         end
+
       private_key_pass = @data[:client_key_pass] || @data[:private_key_pass]
 
-      if certificate_data && private_key_data
-        # Allow clients to pass in already loaded certs and private keys.
-        certificate_data = File.read certificate_data unless certificate_data.gsub(/\n|\r/, '') =~ /-----BEGIN CERTIFICATE.*END CERTIFICATE-----/
-        private_key_data = File.read private_key_data unless private_key_data.gsub(/\n|\r/, '') =~ /-----BEGIN.*PRIVATE KEY.*END.*PRIVATE KEY-----/
-
-        ssl_context.cert = OpenSSL::X509::Certificate.new certificate_data
+      if client_cert_data && private_key_data
+        ssl_context.cert = OpenSSL::X509::Certificate.new client_cert_data
         if OpenSSL::PKey.respond_to? :read
           ssl_context.key = OpenSSL::PKey.read(private_key_data, private_key_pass)
         else

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -202,11 +202,13 @@ Shindo.tests('Excon basics (ssl file)',['focus']) do
       connection.request(:method => :get, :path => '/content-length/100')
     end
 
-    basic_tests('https://127.0.0.1:8443',
-                :client_key => File.join(File.dirname(__FILE__), 'data', 'excon.cert.key'),
-                :client_cert => File.join(File.dirname(__FILE__), 'data', 'excon.cert.crt')
-               )
+    cert_key_path = File.join(File.dirname(__FILE__), 'data', 'excon.cert.key')
+    cert_crt_path = File.join(File.dirname(__FILE__), 'data', 'excon.cert.crt')
+    basic_tests('https://127.0.0.1:8443', client_key: cert_key_path, client_cert: cert_crt_path)
 
+    cert_key_data = File.read cert_key_path
+    cert_crt_data = File.read cert_crt_path
+    basic_tests('https://127.0.0.1:8443', client_key: cert_key_data, client_cert: cert_crt_data)
   end
 end
 

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -208,7 +208,7 @@ Shindo.tests('Excon basics (ssl file)',['focus']) do
 
     cert_key_data = File.read cert_key_path
     cert_crt_data = File.read cert_crt_path
-    basic_tests('https://127.0.0.1:8443', private_key_data: cert_key_data, client_cert_data: cert_crt_data)
+    basic_tests('https://127.0.0.1:8443', client_key_data: cert_key_data, client_cert_data: cert_crt_data)
   end
 end
 

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -208,7 +208,7 @@ Shindo.tests('Excon basics (ssl file)',['focus']) do
 
     cert_key_data = File.read cert_key_path
     cert_crt_data = File.read cert_crt_path
-    basic_tests('https://127.0.0.1:8443', client_key: cert_key_data, client_cert: cert_crt_data)
+    basic_tests('https://127.0.0.1:8443', private_key_data: cert_key_data, client_cert_data: cert_crt_data)
   end
 end
 


### PR DESCRIPTION
This does not allow `:ssl_ca_file` to be already loaded due to how `OpenSSL::SSL::SSLSocket` is implemented. Clients can still benefit from this change if they are using `:ssl_verify_peer => false`.