### PR TITLE
Fix proxy error handling so it doesn't confuse everyone

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -128,7 +128,12 @@ module Excon
       if uri.user
         params[:user] = Utils.unescape_uri(uri.user)
       end
-      Excon::Connection.new(params)
+      begin
+          con = Excon::Connection.new(params)
+      rescue Exception => ex
+          print "Unable to establish Excon connection.\nException detail:\n#{ex}\nDid you set your proxy environment variable correctly?\n\n"
+          raise
+      end
     end
 
     # push an additional stub onto the list to check for mock requests

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -473,11 +473,12 @@ module Excon
             end
           else
             unless uri.host && uri.port && uri.scheme
-              raise Excon::Errors::ProxyParseError, "Proxy is invalid"
+              uriconcat = "scheme: #{uri.scheme}\nhost: #{uri.host}\nport: #{uri.port}"
+              raise Excon::Errors::ProxyParse, "Proxy is invalid.  Value you passed was:\n#{uriconcat}\n"
             end
           end
         else
-          raise Excon::Errors::ProxyParseError, "Proxy is invalid"
+          raise Excon::Errors::ProxyParse, "Proxy is invalid."
         end
 
         if @data.has_key?(:proxy) && @data[:scheme] == 'http'


### PR DESCRIPTION
Wasted an hour today dinking around with the fact that the error handling code for bad proxy environment variables obscures the actual error.  Fixed that.