### PR TITLE
Add missing require 'time'

### DIFF
--- a/spec/support/shared_examples/shared_example_for_clients.rb
+++ b/spec/support/shared_examples/shared_example_for_clients.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 shared_examples_for 'a basic client' do |url = 'http://127.0.0.1:9292', opts = {}|
   # TODO: Ditch iterator and manually write a context for each set of options
   ([true, false] * 2).combination(2).to_a.uniq.each do |nonblock, persistent|


### PR DESCRIPTION
This fixes following errors:

```
$ rspec spec/requests/basic_spec.rb

... snip ...

Failures:

  1) Excon::Connection when an explicit uri is passed when nonblock is true and persistent is false when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
     Failure/Error: time = Time.parse(response.headers['Date'])

     NoMethodError:
       undefined method `parse' for Time:Class
     Shared Example Group: "a basic client" called from ./spec/requests/basic_spec.rb:38
     # ./spec/support/shared_examples/shared_example_for_clients.rb:40:in `block (8 levels) in <top (required)>'

  2) Excon::Connection when an explicit uri is passed when nonblock is true and persistent is true when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
     Failure/Error: time = Time.parse(response.headers['Date'])

     NoMethodError:
       undefined method `parse' for Time:Class
     Shared Example Group: "a basic client" called from ./spec/requests/basic_spec.rb:38
     # ./spec/support/shared_examples/shared_example_for_clients.rb:40:in `block (8 levels) in <top (required)>'

  3) Excon::Connection when an explicit uri is passed when nonblock is false and persistent is true when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
     Failure/Error: time = Time.parse(response.headers['Date'])

     NoMethodError:
       undefined method `parse' for Time:Class
     Shared Example Group: "a basic client" called from ./spec/requests/basic_spec.rb:38
     # ./spec/support/shared_examples/shared_example_for_clients.rb:40:in `block (8 levels) in <top (required)>'

  4) Excon::Connection when an explicit uri is passed when nonblock is false and persistent is false when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
     Failure/Error: time = Time.parse(response.headers['Date'])

     NoMethodError:
       undefined method `parse' for Time:Class
     Shared Example Group: "a basic client" called from ./spec/requests/basic_spec.rb:38
     # ./spec/support/shared_examples/shared_example_for_clients.rb:40:in `block (8 levels) in <top (required)>'

Finished in 2.02 seconds (files took 0.16142 seconds to load)
95 examples, 4 failures

Failed examples:

rspec ./spec/requests/basic_spec.rb[1:1:3:1:1:2:2:3] # Excon::Connection when an explicit uri is passed when nonblock is true and persistent is false when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
rspec ./spec/requests/basic_spec.rb[1:1:4:1:1:2:2:3] # Excon::Connection when an explicit uri is passed when nonblock is true and persistent is true when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
rspec ./spec/requests/basic_spec.rb[1:1:5:1:1:2:2:3] # Excon::Connection when an explicit uri is passed when nonblock is false and persistent is true when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
rspec ./spec/requests/basic_spec.rb[1:1:6:1:1:2:2:3] # Excon::Connection when an explicit uri is passed when nonblock is false and persistent is false when :method is get and :path is /content-length/100 #request Excon::Response#headers ['Date'] returns a valid date
```