### PR TITLE
Use Utils.unescape_uri for user/password in Authorization header

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -218,7 +218,7 @@ module Excon
       datum[:headers] = @data[:headers].merge(datum[:headers] || {})
 
       if datum[:user] || datum[:password]
-        user, pass = Utils.unescape_form(datum[:user].to_s), Utils.unescape_form(datum[:password].to_s)
+        user, pass = Utils.unescape_uri(datum[:user].to_s), Utils.unescape_uri(datum[:password].to_s)
         datum[:headers]['Authorization'] ||= 'Basic ' + ["#{user}:#{pass}"].pack('m').delete(Excon::CR_NL)
       end
 


### PR DESCRIPTION
Should fix https://github.com/excon/excon/issues/604 which I hit
while trying to replicate a `curl` authenticated request whose
credentials include `+`. An identical `excon` request was generating
`401`s, and started to work after applying this change.

I haven't found a test associated to the way this header is encoded,
so I've only verified the change with the comparison mentioned above.