### PR TITLE
Add a accept header to request to prevent blocking from waf devices

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -116,7 +116,8 @@ module Excon
     :debug_request        => false,
     :debug_response       => false,
     :headers              => {
-      'User-Agent' => USER_AGENT
+      'User-Agent' => USER_AGENT,
+      'Accept'     =>  '*/*'
     },
     :idempotent           => false,
     :instrumentor_name    => 'excon',


### PR DESCRIPTION
Add a accept header to request to prevent blocking from waf devices ( for instance a mod_proxy with crs_21_protocol_anomalies rules loaded