### PR TITLE
Use secure RubyGems source URI in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     excon (0.54.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.6)
       i18n (~> 0.6)
@@ -298,4 +298,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.13.1
+   1.14.2


### PR DESCRIPTION
Noticed that the RubyGems source URI in the Gemfile wasn't using HTTPS yet.