### PR TITLE
Fix Gemnasium badge, and update a few other URLs to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Excon was designed to be simple, fast and performant. It works great as a genera
 
 [![Build Status](https://travis-ci.org/excon/excon.svg?branch=master)](https://travis-ci.org/excon/excon)
 [![Dependency Status](https://gemnasium.com/excon/excon.svg)](https://gemnasium.com/excon/excon)
-[![Gem Version](https://badge.fury.io/rb/excon.svg)](http://badge.fury.io/rb/excon)
+[![Gem Version](https://badge.fury.io/rb/excon.svg)](https://badge.fury.io/rb/excon)
 [![Gittip](http://img.shields.io/gittip/geemus.svg)](https://www.gittip.com/geemus/)
 
 * [Getting Started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Usable, fast, simple Ruby HTTP 1.1
 Excon was designed to be simple, fast and performant. It works great as a general HTTP(s) client and is particularly well suited to usage in API clients.
 
 [![Build Status](https://secure.travis-ci.org/excon/excon.svg)](http://travis-ci.org/excon/excon)
-[![Dependency Status](https://gemnasium.com/geemus/excon.svg)](https://gemnasium.com/geemus/excon)
+[![Dependency Status](https://gemnasium.com/excon/excon.svg)](https://gemnasium.com/excon/excon)
 [![Gem Version](https://badge.fury.io/rb/excon.svg)](http://badge.fury.io/rb/excon)
 [![Gittip](http://img.shields.io/gittip/geemus.svg)](https://www.gittip.com/geemus/)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Usable, fast, simple Ruby HTTP 1.1
 
 Excon was designed to be simple, fast and performant. It works great as a general HTTP(s) client and is particularly well suited to usage in API clients.
 
-[![Build Status](https://secure.travis-ci.org/excon/excon.svg)](http://travis-ci.org/excon/excon)
+[![Build Status](https://travis-ci.org/excon/excon.svg?branch=master)](https://travis-ci.org/excon/excon)
 [![Dependency Status](https://gemnasium.com/excon/excon.svg)](https://gemnasium.com/excon/excon)
 [![Gem Version](https://badge.fury.io/rb/excon.svg)](http://badge.fury.io/rb/excon)
 [![Gittip](http://img.shields.io/gittip/geemus.svg)](https://www.gittip.com/geemus/)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Excon was designed to be simple, fast and performant. It works great as a genera
 [![Build Status](https://travis-ci.org/excon/excon.svg?branch=master)](https://travis-ci.org/excon/excon)
 [![Dependency Status](https://gemnasium.com/excon/excon.svg)](https://gemnasium.com/excon/excon)
 [![Gem Version](https://badge.fury.io/rb/excon.svg)](https://badge.fury.io/rb/excon)
-[![Gittip](http://img.shields.io/gittip/geemus.svg)](https://www.gittip.com/geemus/)
+[![Gittip](https://img.shields.io/gittip/geemus.svg)](https://www.gittip.com/geemus/)
 
 * [Getting Started](#getting-started)
 * [Options](#options)


### PR DESCRIPTION
This fixes the broken Gemnasium badge. While I was at it, I updated a few other URLs to use HTTPS as well (if supported).