### PR TITLE
fix Errors::ProxyParseError to Errors::ProxyParse

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -473,11 +473,11 @@ module Excon
             end
           else
             unless uri.host && uri.port && uri.scheme
-              raise Excon::Errors::ProxyParseError, "Proxy is invalid"
+              raise Excon::Errors::ProxyParse, "Proxy is invalid"
             end
           end
         else
-          raise Excon::Errors::ProxyParseError, "Proxy is invalid"
+          raise Excon::Errors::ProxyParse, "Proxy is invalid"
         end
 
         if @data.has_key?(:proxy) && @data[:scheme] == 'http'


### PR DESCRIPTION
I saw #602 which also fixes this error. But there was no activity on that PR for quite a while; and it rescues `Exception` which is considered to be bad practice.
So open this tiny PR to make people with wrong proxy settings a bit happier 😄 