### PR TITLE
Handling url-escaped proxy credentials for ssl sockets

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -85,8 +85,9 @@ module Excon
         request = "CONNECT #{@data[:host]}#{port_string(@data.merge(:omit_default_port => false))}#{Excon::HTTP_1_1}" +
                   "Host: #{@data[:host]}#{port_string(@data)}#{Excon::CR_NL}"
 
-        if @data[:proxy][:password] || @data[:proxy][:user]
-          auth = ["#{@data[:proxy][:user]}:#{@data[:proxy][:password]}"].pack('m').delete(Excon::CR_NL)
+        if @data[:proxy].has_key?(:user) || @data[:proxy].has_key?(:password)
+          user, pass = Utils.unescape_form(@data[:proxy][:user].to_s), Utils.unescape_form(@data[:proxy][:password].to_s)
+          auth = ["#{user}:#{pass}"].pack('m').delete(Excon::CR_NL)
           request += "Proxy-Authorization: Basic #{auth}#{Excon::CR_NL}"
         end
 


### PR DESCRIPTION
Was getting following error when having url-escaped proxy credentials (user or pass) with httpS requests.

```
Excon::Error::Socket: SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: unknown protocol (OpenSSL::SSL::SSLError)
```

I basically just copied over the code from connection.rb file that handles the same thing.