### PR TITLE
Add optional interval between idempotent retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ connection.request(:idempotent => true)
 # this request can be repeated safely, retry up to 6 times
 connection.request(:idempotent => true, :retry_limit => 6)
 
+# this request can be repeated safely, retry up to 6 times and sleep 5 seconds
+# in between each retry
+connection.request(:idempotent => true, :retry_limit => 6, :retry_interval => 5)
+
 # set longer read_timeout (default is 60 seconds)
 connection.request(:read_timeout => 360)
 

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -46,6 +46,7 @@ module Excon
     #     @option params [String] :ciphers Only use the specified SSL/TLS cipher suites; use OpenSSL cipher spec format e.g. 'HIGH:!aNULL:!3DES' or 'AES256-SHA:DES-CBC3-SHA'
     #     @option params [String] :proxy Proxy server; e.g. 'http://myproxy.com:8888'
     #     @option params [Fixnum] :retry_limit Set how many times we'll retry a failed request.  (Default 4)
+    #     @option params [Fixnum] :retry_interval Set how long to wait between retries. (Default 0)
     #     @option params [Class] :instrumentor Responds to #instrument as in ActiveSupport::Notifications
     #     @option params [String] :instrumentor_name Name prefix for #instrument events.  Defaults to 'excon'
     def initialize(params = {})

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -57,6 +57,7 @@ module Excon
     :response_block,
     :retries_remaining, # used internally
     :retry_limit,
+    :retry_interval,
     :versions,
     :write_timeout
   ]

--- a/lib/excon/middlewares/idempotent.rb
+++ b/lib/excon/middlewares/idempotent.rb
@@ -20,6 +20,9 @@ module Excon
 
         if datum[:idempotent] && [Excon::Errors::Timeout, Excon::Errors::SocketError,
             Excon::Errors::HTTPStatusError].any? {|ex| datum[:error].kind_of?(ex) } && datum[:retries_remaining] > 1
+
+          sleep(datum[:retry_interval]) if datum[:retry_interval]
+
           # reduces remaining retries, reset connection, and restart request_call
           datum[:retries_remaining] -= 1
           connection = datum.delete(:connection)


### PR DESCRIPTION
If the :retry_interval parameter is passed then the Idempotent middleware
will sleep for the specified number of seconds between each re-try.

This started as a monkey patch inside a private project.  and I hope that it can be useful to others. 
I think I have updated all the necessary locations:
* added the changed itself to the Idempotent middleware and update the tests
* added :retry_interval to the constant list
* added :retry_interval to the Connection yardoc
* added :retry_interval to the README

Any feedback is greatly appreciated!