### PR TITLE
Don't override Host when talking to UNIX socket

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -223,7 +223,7 @@ module Excon
       end
 
       if datum[:scheme] == UNIX
-        datum[:headers]['Host']   = ''
+        datum[:headers]['Host']   ||= ''
       else
         datum[:headers]['Host']   ||= datum[:host] + port_string(datum)
       end

--- a/spec/requests/unix_socket_spec.rb
+++ b/spec/requests/unix_socket_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe Excon::Connection do
+  context "when speaking to a UNIX socket" do
+    context "Host header handling" do
+      before do
+        responder = ->(req) do
+          {
+            body: req[:headers].to_json,
+            status: 200,
+          }
+        end
+
+        @original_mock = Excon.defaults[:mock]
+        Excon.defaults[:mock] = true
+        Excon.stub({}, responder)
+      end
+
+      after do
+        Excon.defaults[:mock] = @original_mock
+      end
+
+      it "sends an empty Host= by default" do
+        conn = Excon::Connection.new(
+          scheme: "unix",
+          socket: "/tmp/x.sock",
+        )
+
+        headers = JSON.parse(conn.get(path: "/path").body)
+
+        expect(headers["Host"]).to eq("")
+      end
+
+      it "doesn't overwrite an explicit Host header" do
+        conn = Excon::Connection.new(
+          scheme: "unix",
+          socket: "/tmp/x.sock",
+        )
+
+        headers = JSON.parse(conn.get(path: "/path", headers: { "Host" => "localhost" }).body)
+
+        expect(headers["Host"]).to eq("localhost")
+      end
+    end
+  end
+end


### PR DESCRIPTION
As per the RFC, sending Host="" is the correct behavior when speaking to
a URI that has no host (e.g. a UNIX socket):

> If the requested URI does not include an Internet host name for the
> service being requested, then the Host header field MUST be given with
> an empty value

Unfortunately, some web servers treat that the same as an entirely
omitted Host header, which results in a 400 response. To work around
this, one can fabricate and send any valid Host to which the server will
respond.

For Excon to support this use-case, it needs to respect an explicitly
set Host header, even when talking to a UNIX socket.