### PR TITLE
Remove unused error class

### DIFF
--- a/lib/excon/error.rb
+++ b/lib/excon/error.rb
@@ -48,7 +48,6 @@ or:
     class Timeout < Error; end
     class ResponseParse < Error; end
     class ProxyParse < Error; end
-    class ProxyConnection < Error; end
 
     # Base class for HTTP Error classes
     class HTTPStatus < Error


### PR DESCRIPTION
Error class was introduced here: https://github.com/excon/excon/pull/165/files
Usage was removed here: https://github.com/excon/excon/commit/9989457cab47f5d79ddb889d8502ba614e9aeef6

I stumbled upon this while looking at Errors used by the project.