### PR TITLE
Add Connection#requests_in_batches method

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ connection.requests([{:method => :get}, {:method => :get}])
 By default, each call to `requests` will use a separate persistent socket connection. To make multiple `requests` calls
 using a single persistent connection, set `:persistent => true` when establishing the connection.
 
+For large numbers of simultaneous requests please consider using the `batch_requests` method. This will automatically slice up the requests into batches based on the file descriptor limit of your operating system. The results are the same as the `requests` method, but using this method can help prevent timeout errors.
+
+```ruby
+large_array_of_requests = [{:method => :get, :path => 'some_path'}, { ... }] # Hundreds of items
+connection.batch_requests(large_array_of_requests)
+```
+
 ## Streaming Responses
 
 You can stream responses by passing a block that will receive each chunk.

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -301,6 +301,19 @@ module Excon
       responses
     end
 
+    # Sends the supplied requests to the destination host using pipelining in
+    # batches of @limit [Numeric] requests. This is 256 by default.
+    #   @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
+    def requests_in_batches(pipeline_params, limit = 256)
+      responses = []
+
+      pipeline_params.each_slice(limit) do |params|
+        responses.concat(requests(params))
+      end
+
+      responses
+    end
+
     def reset
       if old_socket = sockets.delete(@socket_key)
         old_socket.close rescue nil

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -302,9 +302,11 @@ module Excon
     end
 
     # Sends the supplied requests to the destination host using pipelining in
-    # batches of @limit [Numeric] requests. This is 256 by default.
+    # batches of @limit [Numeric] requests. This is your soft file descriptor
+    # limit by default, typically 256.
     #   @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
-    def requests_in_batches(pipeline_params, limit = 256)
+    def batch_requests(pipeline_params, limit = nil)
+      limit ||= Process.respond_to?(:getrlimit) ? Process.getrlimit(:NOFILE).first : 256
       responses = []
 
       pipeline_params.each_slice(limit) do |params|

--- a/tests/batch_requests.rb
+++ b/tests/batch_requests.rb
@@ -1,0 +1,133 @@
+require 'shindo'
+
+Shindo.tests('Batch Requests') do
+  with_server('good') do
+    tests('with batch request size 2') do
+      returns(%w{ 1 2 1 2 }, 'batch request size 2') do
+        connection = Excon.new('http://127.0.0.1:9292')
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 2).map(&:body)
+
+        ret.flatten
+      end
+    end
+
+    tests('peristent with batch request size 2') do
+      returns(%w{ 1 2 3 4 }, 'persistent batch request size 2') do
+        connection = Excon.new('http://127.0.0.1:9292', :persistent => true)
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 2).map(&:body)
+
+        ret.flatten
+      end
+    end
+
+    tests('with batch request size 3') do
+      returns(%w{ 1 2 3 1 }, 'batch request size 3') do
+        connection = Excon.new('http://127.0.0.1:9292')
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 3).map(&:body)
+
+        ret.flatten
+      end
+    end
+
+    tests('persistent with batch request size 3') do
+      returns(%w{ 1 2 3 4 }, 'persistent batch request size 3') do
+        connection = Excon.new('http://127.0.0.1:9292', :persistent => true)
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 3).map(&:body)
+
+        ret.flatten
+      end
+    end
+
+    tests('with batch request size 4') do
+      returns(%w{ 1 2 3 4 }, 'batch request size 4') do
+        connection = Excon.new('http://127.0.0.1:9292')
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 4).map(&:body)
+
+        ret.flatten
+      end
+    end
+
+    tests('persistent with batch request size 4') do
+      returns(%w{ 1 2 3 4 }, 'persistent batch request size 4') do
+        connection = Excon.new('http://127.0.0.1:9292', :persistent => true)
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 4).map(&:body)
+
+        ret.flatten
+      end
+    end
+
+    tests('with batch request size 8') do
+      returns(%w{ 1 2 3 4 }, 'batch request size 8') do
+        connection = Excon.new('http://127.0.0.1:9292')
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 8).map(&:body)
+
+        ret.flatten
+      end
+    end
+
+    tests('persistent with batch request size 8') do
+      returns(%w{ 1 2 3 4 }, 'persistent batch request size 8') do
+        connection = Excon.new('http://127.0.0.1:9292', :persistent => true)
+
+        ret = []
+        ret << connection.batch_requests([
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'},
+          {:method => :get, :path => '/echo/request_count'}
+        ], 8).map(&:body)
+
+        ret.flatten
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a simple wrapper for the `Connection#requests` method that allows users to chop up large request sets into smaller batches. What I noticed in practice is that somewhere around 500 simultaneous requests I would get a heavy increase in write time that I couldn't predict, resulting in a timeout error even after setting `:write_timeout` to 5 minutes.

Conversely, I was able to send multiple batches of 250-300 simultaneous requests with the default timeout and receive results in under 2 minutes. So, what I end up doing in practice is slicing up the requests into groups via `each_slice` and collating them into a single result set.

This PR is just a handy wrapper around `Array#each_slice` and `Connection#requests`, with a default slice set at 256.

Addresses https://github.com/excon/excon/issues/646