### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 doc
 rdoc
 pkg
+Gemfile.lock


### PR DESCRIPTION
I don't think you want to include the Gemfile.lock in your checkins. :)

For me at least a `bundle install` will fail because of eventmachine set at 1.0.4 in the lockfile (current version is 1.2.5).