### PR TITLE
Refactor gemspec

### DIFF
--- a/excon.gemspec
+++ b/excon.gemspec
@@ -1,59 +1,19 @@
-## This is the rakegem gemspec template. Make sure you read and understand
-## all of the comments. Some sections require modification, and others can
-## be deleted if you don't need them. Once you understand the contents of
-## this file, feel free to delete any comments that begin with two hash marks.
-## You can find comprehensive Gem::Specification documentation, at
-## http://docs.rubygems.org/read/chapter/20
+require File.join(File.dirname(__FILE__), 'lib', 'excon', 'version')
+
 Gem::Specification.new do |s|
-  s.specification_version = 2 if s.respond_to? :specification_version=
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.rubygems_version = '1.3.5'
+  s.name             = 'excon'
+  s.version          = Excon::VERSION
+  s.summary          = "speed, persistence, http(s)"
+  s.description      = "EXtended http(s) CONnections"
+  s.authors          = ["dpiddy (Dan Peterson)", "geemus (Wesley Beary)", "nextmat (Matt Sanders)"]
+  s.email            = 'geemus@gmail.com'
+  s.homepage         = 'https://github.com/excon/excon'
+  s.license          = 'MIT'
+  s.rdoc_options     = ["--charset=UTF-8"]
+  s.extra_rdoc_files = %w[README.md CONTRIBUTORS.md CONTRIBUTING.md]
+  s.files            = `git ls-files -z`.split("\x0")
+  s.test_files       = s.files.select { |path| path =~ /^[spec|tests]\/.*_[spec|tests]\.rb/ }
 
-  ## Leave these as is they will be modified for you by the rake gemspec task.
-  ## If your rubyforge_project name is different, then edit it and comment out
-  ## the sub! line in the Rakefile
-  s.name              = 'excon'
-  s.version           = '0.59.0'
-  s.date              = '2017-09-05'
-  s.rubyforge_project = 'excon'
-
-  ## Make sure your summary is short. The description may be as long
-  ## as you like.
-  s.summary     = "speed, persistence, http(s)"
-  s.description = "EXtended http(s) CONnections"
-
-  ## List the primary authors. If there are a bunch of authors, it's probably
-  ## better to set the email to an email list or something. If you don't have
-  ## a custom homepage, consider using your GitHub URL or the like.
-  s.authors  = ["dpiddy (Dan Peterson)", "geemus (Wesley Beary)", "nextmat (Matt Sanders)"]
-  s.email    = 'geemus@gmail.com'
-  s.homepage = 'https://github.com/excon/excon'
-  s.license  = 'MIT'
-
-  ## This gets added to the $LOAD_PATH so that 'lib/NAME.rb' can be required as
-  ## require 'NAME.rb' or'/lib/NAME/file.rb' can be as require 'NAME/file.rb'
-  s.require_paths = %w[lib]
-
-  ## This sections is only necessary if you have C extensions.
-  # s.require_paths << 'ext'
-  # s.extensions = %w[ext/extconf.rb]
-
-  ## If your gem includes any executables, list them here.
-  # s.executables = ["name"]
-  # s.default_executable = 'name'
-
-  ## Specify any RDoc options here. You'll want to add your README and
-  ## LICENSE files to the extra_rdoc_files list.
-  s.rdoc_options = ["--charset=UTF-8"]
-  s.extra_rdoc_files = %w[README.md]
-
-  ## List your runtime dependencies here. Runtime dependencies are those
-  ## that are needed for an end user to actually USE your code.
-  # s.add_dependency('DEPNAME', [">= 1.1.0", "< 2.0.0"])
-
-  ## List your development dependencies here. Development dependencies are
-  ## those that are only needed during development
-  # s.add_development_dependency('DEVDEPNAME', [">= 1.1.0", "< 2.0.0"])
   s.add_development_dependency('rspec', '>= 3.5.0')
   s.add_development_dependency('activesupport')
   s.add_development_dependency('delorean')
@@ -65,138 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sinatra')
   s.add_development_dependency('sinatra-contrib')
   s.add_development_dependency('json', '>= 1.8.5')
-  if RUBY_VERSION.to_f >= 1.9
-      s.add_development_dependency 'puma'
-  end
-  ## Leave this section as-is. It will be automatically generated from the
-  ## contents of your Git repository via the gemspec task. DO NOT REMOVE
-  ## THE MANIFEST COMMENTS, they are used as delimiters by the task.
-  # = MANIFEST =
-  s.files = %w[
-    CONTRIBUTING.md
-    CONTRIBUTORS.md
-    Gemfile
-    Gemfile.lock
-    LICENSE.md
-    README.md
-    Rakefile
-    benchmarks/class_vs_lambda.rb
-    benchmarks/concat_vs_insert.rb
-    benchmarks/concat_vs_interpolate.rb
-    benchmarks/cr_lf.rb
-    benchmarks/downcase-eq-eq_vs_casecmp.rb
-    benchmarks/excon.rb
-    benchmarks/excon_vs.rb
-    benchmarks/for_vs_array_each.rb
-    benchmarks/for_vs_hash_each.rb
-    benchmarks/has_key-vs-lookup.rb
-    benchmarks/headers_case_sensitivity.rb
-    benchmarks/headers_split_vs_match.rb
-    benchmarks/implicit_block-vs-explicit_block.rb
-    benchmarks/merging.rb
-    benchmarks/single_vs_double_quotes.rb
-    benchmarks/string_ranged_index.rb
-    benchmarks/strip_newline.rb
-    benchmarks/vs_stdlib.rb
-    changelog.txt
-    data/cacert.pem
-    excon.gemspec
-    lib/excon.rb
-    lib/excon/connection.rb
-    lib/excon/constants.rb
-    lib/excon/error.rb
-    lib/excon/extensions/uri.rb
-    lib/excon/headers.rb
-    lib/excon/middlewares/base.rb
-    lib/excon/middlewares/capture_cookies.rb
-    lib/excon/middlewares/decompress.rb
-    lib/excon/middlewares/escape_path.rb
-    lib/excon/middlewares/expects.rb
-    lib/excon/middlewares/idempotent.rb
-    lib/excon/middlewares/instrumentor.rb
-    lib/excon/middlewares/mock.rb
-    lib/excon/middlewares/redirect_follower.rb
-    lib/excon/middlewares/response_parser.rb
-    lib/excon/pretty_printer.rb
-    lib/excon/response.rb
-    lib/excon/socket.rb
-    lib/excon/ssl_socket.rb
-    lib/excon/standard_instrumentor.rb
-    lib/excon/test/plugin/server/exec.rb
-    lib/excon/test/plugin/server/puma.rb
-    lib/excon/test/plugin/server/unicorn.rb
-    lib/excon/test/plugin/server/webrick.rb
-    lib/excon/test/server.rb
-    lib/excon/unix_socket.rb
-    lib/excon/utils.rb
-    spec/excon/error_spec.rb
-    spec/excon/test/server_spec.rb
-    spec/excon_spec.rb
-    spec/helpers/file_path_helpers.rb
-    spec/requests/basic_spec.rb
-    spec/requests/eof_requests_spec.rb
-    spec/requests/unix_socket_spec.rb
-    spec/spec_helper.rb
-    spec/support/shared_contexts/test_server_context.rb
-    spec/support/shared_examples/shared_example_for_clients.rb
-    spec/support/shared_examples/shared_example_for_streaming_clients.rb
-    spec/support/shared_examples/shared_example_for_test_servers.rb
-    tests/authorization_header_tests.rb
-    tests/bad_tests.rb
-    tests/basic_tests.rb
-    tests/complete_responses.rb
-    tests/data/127.0.0.1.cert.crt
-    tests/data/127.0.0.1.cert.key
-    tests/data/excon.cert.crt
-    tests/data/excon.cert.key
-    tests/data/xs
-    tests/error_tests.rb
-    tests/header_tests.rb
-    tests/middlewares/canned_response_tests.rb
-    tests/middlewares/capture_cookies_tests.rb
-    tests/middlewares/decompress_tests.rb
-    tests/middlewares/escape_path_tests.rb
-    tests/middlewares/idempotent_tests.rb
-    tests/middlewares/instrumentation_tests.rb
-    tests/middlewares/mock_tests.rb
-    tests/middlewares/redirect_follower_tests.rb
-    tests/pipeline_tests.rb
-    tests/proxy_tests.rb
-    tests/query_string_tests.rb
-    tests/rackups/basic.rb
-    tests/rackups/basic.ru
-    tests/rackups/basic_auth.ru
-    tests/rackups/deflater.ru
-    tests/rackups/proxy.ru
-    tests/rackups/query_string.ru
-    tests/rackups/redirecting.ru
-    tests/rackups/redirecting_with_cookie.ru
-    tests/rackups/request_headers.ru
-    tests/rackups/request_methods.ru
-    tests/rackups/response_header.ru
-    tests/rackups/ssl.ru
-    tests/rackups/ssl_mismatched_cn.ru
-    tests/rackups/ssl_verify_peer.ru
-    tests/rackups/streaming.ru
-    tests/rackups/thread_safety.ru
-    tests/rackups/timeout.ru
-    tests/rackups/webrick_patch.rb
-    tests/request_headers_tests.rb
-    tests/request_method_tests.rb
-    tests/request_tests.rb
-    tests/response_tests.rb
-    tests/servers/bad.rb
-    tests/servers/eof.rb
-    tests/servers/error.rb
-    tests/servers/good.rb
-    tests/test_helper.rb
-    tests/thread_safety_tests.rb
-    tests/timeout_tests.rb
-    tests/utils_tests.rb
-  ]
-  # = MANIFEST =
-
-  ## Test files will be grabbed from the file list. Make sure the path glob
-  ## matches what you actually use.
-  s.test_files = s.files.select { |path| path =~ /^[spec|tests]\/.*_[spec|tests]\.rb/ }
+  s.add_development_dependency('puma')
 end


### PR DESCRIPTION
The gemspec for excon looks like it's some junky autogenerated thing from years ago. This PR cleans it up. I can address some of these specifically:

* specification_version - You shouldn't be messing with this. It is automatically set.
* required_rubygems_version - You shouldn't care at this point.
* rubygems_version - Same.
* rubyforge_project - RubyForge is dead.
* date - Automatically set by Rubygems.
* require_paths - The 'lib' directory is automatically set by Rubygems.
* files - Just use `git ls-files` instead of listing them individually.

With this configuration I ran `gem build excon.gemspec`. The generated spec looks like so:

```
--- !ruby/object:Gem::Specification
name: excon
version: !ruby/object:Gem::Version
  version: 0.59.0
platform: ruby
authors:
- dpiddy (Dan Peterson)
- geemus (Wesley Beary)
- nextmat (Matt Sanders)
autorequire: 
bindir: bin
cert_chain: []
date: 2017-10-18 00:00:00.000000000 Z
dependencies:
- !ruby/object:Gem::Dependency
  name: rspec
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: 3.5.0
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: 3.5.0
- !ruby/object:Gem::Dependency
  name: activesupport
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: delorean
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: eventmachine
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: 1.0.4
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: 1.0.4
- !ruby/object:Gem::Dependency
  name: open4
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: rake
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: rdoc
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: shindo
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: sinatra
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: sinatra-contrib
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
- !ruby/object:Gem::Dependency
  name: json
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: 1.8.5
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: 1.8.5
- !ruby/object:Gem::Dependency
  name: puma
  requirement: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
  type: :development
  prerelease: false
  version_requirements: !ruby/object:Gem::Requirement
    requirements:
    - - ">="
      - !ruby/object:Gem::Version
        version: '0'
description: EXtended http(s) CONnections
email: geemus@gmail.com
executables: []
extensions: []
extra_rdoc_files:
- README.md
- CONTRIBUTORS.md
- CONTRIBUTING.md
files:
- ".document"
- ".gitignore"
- ".rspec"
- ".travis.yml"
- CONTRIBUTING.md
- CONTRIBUTORS.md
- Gemfile
- Gemfile.lock
- LICENSE.md
- README.md
- Rakefile
- benchmarks/class_vs_lambda.rb
- benchmarks/concat_vs_insert.rb
- benchmarks/concat_vs_interpolate.rb
- benchmarks/cr_lf.rb
- benchmarks/downcase-eq-eq_vs_casecmp.rb
- benchmarks/excon.rb
- benchmarks/excon_vs.rb
- benchmarks/for_vs_array_each.rb
- benchmarks/for_vs_hash_each.rb
- benchmarks/has_key-vs-lookup.rb
- benchmarks/headers_case_sensitivity.rb
- benchmarks/headers_split_vs_match.rb
- benchmarks/implicit_block-vs-explicit_block.rb
- benchmarks/merging.rb
- benchmarks/single_vs_double_quotes.rb
- benchmarks/string_ranged_index.rb
- benchmarks/strip_newline.rb
- benchmarks/vs_stdlib.rb
- changelog.txt
- data/cacert.pem
- excon.gemspec
- lib/excon.rb
- lib/excon/connection.rb
- lib/excon/constants.rb
- lib/excon/error.rb
- lib/excon/extensions/uri.rb
- lib/excon/headers.rb
- lib/excon/middlewares/base.rb
- lib/excon/middlewares/capture_cookies.rb
- lib/excon/middlewares/decompress.rb
- lib/excon/middlewares/escape_path.rb
- lib/excon/middlewares/expects.rb
- lib/excon/middlewares/idempotent.rb
- lib/excon/middlewares/instrumentor.rb
- lib/excon/middlewares/mock.rb
- lib/excon/middlewares/redirect_follower.rb
- lib/excon/middlewares/response_parser.rb
- lib/excon/pretty_printer.rb
- lib/excon/response.rb
- lib/excon/socket.rb
- lib/excon/ssl_socket.rb
- lib/excon/standard_instrumentor.rb
- lib/excon/test/plugin/server/exec.rb
- lib/excon/test/plugin/server/puma.rb
- lib/excon/test/plugin/server/unicorn.rb
- lib/excon/test/plugin/server/webrick.rb
- lib/excon/test/server.rb
- lib/excon/unix_socket.rb
- lib/excon/utils.rb
- spec/excon/error_spec.rb
- spec/excon/test/server_spec.rb
- spec/excon_spec.rb
- spec/helpers/file_path_helpers.rb
- spec/requests/basic_spec.rb
- spec/requests/eof_requests_spec.rb
- spec/requests/unix_socket_spec.rb
- spec/spec_helper.rb
- spec/support/shared_contexts/test_server_context.rb
- spec/support/shared_examples/shared_example_for_clients.rb
- spec/support/shared_examples/shared_example_for_streaming_clients.rb
- spec/support/shared_examples/shared_example_for_test_servers.rb
- tests/authorization_header_tests.rb
- tests/bad_tests.rb
- tests/basic_tests.rb
- tests/complete_responses.rb
- tests/data/127.0.0.1.cert.crt
- tests/data/127.0.0.1.cert.key
- tests/data/excon.cert.crt
- tests/data/excon.cert.key
- tests/data/xs
- tests/error_tests.rb
- tests/header_tests.rb
- tests/middlewares/canned_response_tests.rb
- tests/middlewares/capture_cookies_tests.rb
- tests/middlewares/decompress_tests.rb
- tests/middlewares/escape_path_tests.rb
- tests/middlewares/idempotent_tests.rb
- tests/middlewares/instrumentation_tests.rb
- tests/middlewares/mock_tests.rb
- tests/middlewares/redirect_follower_tests.rb
- tests/pipeline_tests.rb
- tests/proxy_tests.rb
- tests/query_string_tests.rb
- tests/rackups/basic.rb
- tests/rackups/basic.ru
- tests/rackups/basic_auth.ru
- tests/rackups/deflater.ru
- tests/rackups/proxy.ru
- tests/rackups/query_string.ru
- tests/rackups/redirecting.ru
- tests/rackups/redirecting_with_cookie.ru
- tests/rackups/request_headers.ru
- tests/rackups/request_methods.ru
- tests/rackups/response_header.ru
- tests/rackups/ssl.ru
- tests/rackups/ssl_mismatched_cn.ru
- tests/rackups/ssl_verify_peer.ru
- tests/rackups/streaming.ru
- tests/rackups/thread_safety.ru
- tests/rackups/timeout.ru
- tests/rackups/webrick_patch.rb
- tests/request_headers_tests.rb
- tests/request_method_tests.rb
- tests/request_tests.rb
- tests/response_tests.rb
- tests/servers/bad.rb
- tests/servers/eof.rb
- tests/servers/error.rb
- tests/servers/good.rb
- tests/test_helper.rb
- tests/thread_safety_tests.rb
- tests/timeout_tests.rb
- tests/utils_tests.rb
homepage: https://github.com/excon/excon
licenses:
- MIT
metadata: {}
post_install_message: 
rdoc_options:
- "--charset=UTF-8"
require_paths:
- lib
required_ruby_version: !ruby/object:Gem::Requirement
  requirements:
  - - ">="
    - !ruby/object:Gem::Version
      version: '0'
required_rubygems_version: !ruby/object:Gem::Requirement
  requirements:
  - - ">="
    - !ruby/object:Gem::Version
      version: '0'
requirements: []
rubyforge_project: 
rubygems_version: 2.6.14
signing_key: 
specification_version: 4
summary: speed, persistence, http(s)
test_files: []
```