### PR TITLE
Add support for tcp keepalive

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -74,6 +74,7 @@ module Excon
     :private_key_path,
     :connect_timeout,
     :family,
+    :keepalive,
     :host,
     :hostname,
     :omit_default_port,

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -151,6 +151,15 @@ module Excon
                            ::Socket::TCP_NODELAY,
                            true)
       end
+
+      if @data[:keepalive]
+        if [:SOL_SOCKET, :SO_KEEPALIVE, :SOL_TCP, :TCP_KEEPIDLE, :TCP_KEEPINTVL, :TCP_KEEPCNT].all?{|c| ::Socket.const_defined? c}
+          @socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE, true)
+          @socket.setsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPIDLE, @data[:keepalive][:time])
+          @socket.setsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPINTVL, @data[:keepalive][:intvl])
+          @socket.setsockopt(::Socket::SOL_TCP, ::Socket::TCP_KEEPCNT, @data[:keepalive][:probes])
+        end
+      end
     end
 
     def read_nonblock(max_length)


### PR DESCRIPTION
This cribs heavily from the way the ruby redis driver handles this issue.  I'm using this with a pool of persistent connections with elasticsearch.