### PR TITLE
Remove binmode call to keep string encoding

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -163,7 +163,7 @@ module Excon
           elsif body.nil?
             socket.write(request) # write out request + headers
           else # write out body
-            if body.respond_to?(:binmode)
+            if body.respond_to?(:binmode) && !body.is_a?(StringIO)
               body.binmode
             end
             if body.respond_to?(:rewind)

--- a/spec/support/shared_examples/shared_example_for_clients.rb
+++ b/spec/support/shared_examples/shared_example_for_clients.rb
@@ -163,6 +163,15 @@ shared_examples_for 'a basic client' do |url = 'http://127.0.0.1:9292', opts = {
             end
 
             context 'when a string is the body paramter' do
+              it 'does not change the econding of the body' do
+                skip unless RUBY_VERSION >= '1.9'
+
+                string_body = '¥£€'
+                expect do
+                  conn.request(method: :post, path: '/echo', body: string_body)
+                end.to_not change { string_body.encoding }
+              end
+
               context 'without request_block' do
                 describe Excon::Response do
                   it "#body equals 'x' * 100)" do


### PR DESCRIPTION
Removes the `.binmode` call for `String` bodies so that the original encoding of the body is retained after the request is made.

Fix for issue https://github.com/excon/excon/issues/606
