### PR TITLE
Allow setting min/max SSL version with OpenSSL gem 2.1

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -91,6 +91,8 @@ module Excon
     :ssl_verify_peer,
     :ssl_verify_peer_host,
     :ssl_version,
+    :ssl_min_version,
+    :ssl_max_version,
     :tcp_nodelay,
     :thread_safe_sockets,
     :uri_parser,

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -27,6 +27,13 @@ module Excon
       if @data[:ssl_version]
         ssl_context.ssl_version = @data[:ssl_version]
       end
+      if @data[:ssl_min_version]
+        ssl_context.min_version = @data[:ssl_min_version]
+      end
+      if @data[:ssl_max_version]
+        ssl_context.max_version = @data[:ssl_max_version]
+      end
+
 
       if @data[:ssl_verify_peer]
         # turn verification on


### PR DESCRIPTION
The functionality in the OpenSSL gem was introduced in ruby/openssl#142 and supported by Net::HTTP in Ruby 2.5: https://github.com/ruby/ruby/commit/dcea9198a9d80bdf4eeacd9d9e9d883850a4a8d2

An example why this might be useful; for payment data the PCI DSS [mandates](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls) that TLS 1.1 or newer is used after June 30. Using `ssl_version` would disallow the client negotiating TLS 1.2 (or 1.3 in the near future) if both sides support it, `min_version` doesn't have this problem.