### PR TITLE
Raise on warnings in tests

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -61,6 +61,14 @@ module Excon
       if $VERBOSE || ENV['EXCON_DEBUG']
         $stderr.puts "[excon][WARNING] #{warning}\n#{ caller.join("\n") }"
       end
+
+      if @raise_on_warnings
+        raise warning
+      end
+    end
+
+    def set_raise_on_warnings!(should_raise)
+      @raise_on_warnings = should_raise
     end
 
     # Status of mocking

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -278,6 +278,10 @@ module Excon
       end
     rescue => error
       reset
+
+      # If we didn't get far enough to initialize datum and the middleware stack, just raise
+      raise error if !datum
+
       datum[:error] = error
       if datum[:stack]
         datum[:stack].error_call(datum)

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -33,6 +33,7 @@ module Excon
   VERSIONS = "#{USER_AGENT} (#{RUBY_PLATFORM}) ruby/#{RUBY_VERSION}"
 
   VALID_REQUEST_KEYS = [
+    :allow_unstubbed_requests,
     :body,
     :captures,
     :chunk_size,
@@ -43,9 +44,11 @@ module Excon
     :idempotent,
     :instrumentor,
     :instrumentor_name,
+    :logger,
     :method,
     :middlewares,
     :mock,
+    :password,
     :path,
     :persistent,
     :pipeline,
@@ -56,6 +59,8 @@ module Excon
     :retries_remaining, # used internally
     :retry_limit,
     :retry_interval,
+    :stubs,
+    :user,
     :versions,
     :write_timeout
   ]
@@ -79,7 +84,6 @@ module Excon
     :omit_default_port,
     :nonblock,
     :reuseaddr,
-    :password,
     :port,
     :proxy,
     :scheme,
@@ -93,10 +97,10 @@ module Excon
     :ssl_version,
     :ssl_min_version,
     :ssl_max_version,
+    :ssl_uri_schemes,
     :tcp_nodelay,
     :thread_safe_sockets,
     :uri_parser,
-    :user
   ]
 
   unless ::IO.const_defined?(:WaitReadable)

--- a/spec/helpers/warning_helpers.rb
+++ b/spec/helpers/warning_helpers.rb
@@ -1,0 +1,9 @@
+def silence_warnings
+  orig_verbose = $VERBOSE
+  $VERBOSE = nil
+  Excon.set_raise_on_warnings!(false)
+  yield
+ensure
+  $VERBOSE = orig_verbose
+  Excon.set_raise_on_warnings!(true)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ RSpec.configure do |config|
   if config.files_to_run.one?
     config.default_formatter = 'doc'
   end
+
+  Excon.set_raise_on_warnings!(true)
 end
 
 # Load helpers

--- a/spec/support/shared_examples/shared_example_for_clients.rb
+++ b/spec/support/shared_examples/shared_example_for_clients.rb
@@ -91,8 +91,10 @@ shared_examples_for 'a basic client' do |url = 'http://127.0.0.1:9292', opts = {
             data = []
             it 'yields with a chunk, remaining length, and total length' do
               expect do
-                conn.request(method: :get, path: '/content-length/100') do |chunk, remaining_length, total_length|
-                  data = [chunk, remaining_length, total_length]
+                silence_warnings do
+                  conn.request(method: :get, path: '/content-length/100') do |chunk, remaining_length, total_length|
+                    data = [chunk, remaining_length, total_length]
+                  end
                 end
               end.to_not raise_error
             end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -9,6 +9,7 @@ Excon.defaults.merge!(
   :read_timeout     => 5,
   :write_timeout    => 5
 )
+Excon.set_raise_on_warnings!(true)
 
 def basic_tests(url = 'http://127.0.0.1:9292', options = {})
   ([true, false] * 2).combination(2).to_a.uniq.each do |nonblock, persistent|
@@ -214,9 +215,11 @@ end
 def silence_warnings
   orig_verbose = $VERBOSE
   $VERBOSE = nil
+  Excon.set_raise_on_warnings!(false)
   yield
 ensure
   $VERBOSE = orig_verbose
+  Excon.set_raise_on_warnings!(true)
 end
 
 def capture_response_block

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -4,6 +4,8 @@ require 'excon'
 require 'delorean'
 require 'open4'
 
+require './spec/helpers/warning_helpers.rb'
+
 Excon.defaults.merge!(
   :connect_timeout  => 5,
   :read_timeout     => 5,
@@ -210,16 +212,6 @@ end
 
 def env_stack
   @env_stack ||= []
-end
-
-def silence_warnings
-  orig_verbose = $VERBOSE
-  $VERBOSE = nil
-  Excon.set_raise_on_warnings!(false)
-  yield
-ensure
-  $VERBOSE = orig_verbose
-  Excon.set_raise_on_warnings!(true)
 end
 
 def capture_response_block


### PR DESCRIPTION
Currently Excon tests trigger a `report_warning` in several places that indicate bugs in the code (missing items in the list of valid parameter keys). The tests don't display these warnings so it's difficult to catch this kind of regression. This PR makes it such that tests fail on warnings and updates the code to avoid warnings in tests. This will also facilitate testing the changes in #289 since that will add new warnings and validation behavior.

I used `Excon.set_raise_on_warnings!` to avoid introducing another global variable but I'm open to other implementations.