### PR TITLE
Validate parameters keys based on middleware stack (#289)

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -63,7 +63,7 @@ module Excon
       end
 
       if @raise_on_warnings
-        raise warning
+        raise Error::Warning.new(warning)
       end
     end
 

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -35,19 +35,14 @@ module Excon
   VALID_REQUEST_KEYS = [
     :allow_unstubbed_requests,
     :body,
-    :captures,
     :chunk_size,
     :debug_request,
     :debug_response,
-    :expects,
     :headers,
-    :idempotent,
-    :instrumentor,
-    :instrumentor_name,
+    :instrumentor, # Used for setting logging within Connection
     :logger,
     :method,
     :middlewares,
-    :mock,
     :password,
     :path,
     :persistent,
@@ -56,9 +51,6 @@ module Excon
     :read_timeout,
     :request_block,
     :response_block,
-    :retries_remaining, # used internally
-    :retry_limit,
-    :retry_interval,
     :stubs,
     :user,
     :versions,
@@ -103,6 +95,17 @@ module Excon
     :thread_safe_sockets,
     :uri_parser,
   ]
+
+  DEPRECATED_VALID_REQUEST_KEYS = {
+    :captures => 'Mock',
+    :expects => 'Expects',
+    :idempotent => 'Idempotent',
+    :instrumentor_name => 'Instrumentor',
+    :mock => 'Mock',
+    :retries_remaining => 'Idempotent', # referenced in Instrumentor, but only relevant with Idempotent
+    :retry_limit => 'Idempotent', # referenced in Instrumentor, but only relevant with Idempotent
+    :retry_interval => 'Idempotent'
+  }
 
   unless ::IO.const_defined?(:WaitReadable)
     class ::IO

--- a/lib/excon/error.rb
+++ b/lib/excon/error.rb
@@ -6,6 +6,7 @@ module Excon
 
     class StubNotFound < Error; end
     class InvalidStub < Error; end
+    class Warning < Error; end
 
     # Socket related errors
     class Socket < Error

--- a/lib/excon/middlewares/base.rb
+++ b/lib/excon/middlewares/base.rb
@@ -2,6 +2,12 @@
 module Excon
   module Middleware
     class Base
+      # Returns the list of parameters that this middleware uses that are valid
+      # as arguments to `Connection#request` or `Connection#new`.
+      def self.valid_parameter_keys
+        []
+      end
+
       def initialize(stack)
         @stack = stack
       end

--- a/lib/excon/middlewares/expects.rb
+++ b/lib/excon/middlewares/expects.rb
@@ -2,6 +2,12 @@
 module Excon
   module Middleware
     class Expects < Excon::Middleware::Base
+      def self.valid_parameter_keys
+        [
+          :expects
+        ]
+      end
+
       def response_call(datum)
         if datum.has_key?(:expects) && ![*datum[:expects]].include?(datum[:response][:status])
           raise(

--- a/lib/excon/middlewares/idempotent.rb
+++ b/lib/excon/middlewares/idempotent.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
+require 'set'
+
 module Excon
   module Middleware
     class Idempotent < Excon::Middleware::Base
+      def self.valid_parameter_keys
+        [
+          :idempotent,
+          :retries_remaining,
+          :retry_interval,
+          :retry_limit
+        ]
+      end
+
+      def request_call(datum)
+        datum[:retries_remaining] ||= datum[:retry_limit]
+        @stack.request_call(datum)
+      end
+
       def error_call(datum)
         if datum[:idempotent]
           if datum.has_key?(:request_block)
@@ -29,7 +45,8 @@ module Excon
           # reduces remaining retries, reset connection, and restart request_call
           datum[:retries_remaining] -= 1
           connection = datum.delete(:connection)
-          datum.reject! {|key, _| !Excon::VALID_REQUEST_KEYS.include?(key) }
+          valid_keys = Set.new(connection.valid_request_keys(datum[:middlewares]))
+          datum.select! {|key, _| valid_keys.include?(key) }
           connection.request(datum)
         else
           @stack.error_call(datum)

--- a/lib/excon/middlewares/instrumentor.rb
+++ b/lib/excon/middlewares/instrumentor.rb
@@ -2,6 +2,14 @@
 module Excon
   module Middleware
     class Instrumentor < Excon::Middleware::Base
+      def self.valid_parameter_keys
+        [
+          :logger,
+          :instrumentor,
+          :instrumentor_name
+        ]
+      end
+
       def error_call(datum)
         if datum.has_key?(:instrumentor)
           datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.error", :error => datum[:error]) do

--- a/lib/excon/middlewares/mock.rb
+++ b/lib/excon/middlewares/mock.rb
@@ -2,6 +2,14 @@
 module Excon
   module Middleware
     class Mock < Excon::Middleware::Base
+      def self.valid_parameter_keys
+        [
+          :allow_unstubbed_requests,
+          :captures,
+          :mock
+        ]
+      end
+
       def request_call(datum)
         if datum[:mock]
           # convert File/Tempfile body to string before matching:

--- a/spec/requests/unix_socket_spec.rb
+++ b/spec/requests/unix_socket_spec.rb
@@ -1,25 +1,17 @@
 require "spec_helper"
 
 describe Excon::Connection do
+  include_context('stubs')
   context "when speaking to a UNIX socket" do
     context "Host header handling" do
       before do
-        responder = ->(req) do
+        Excon.stub do |req|
           {
             body: req[:headers].to_json,
             status: 200,
           }
         end
-
-        @original_mock = Excon.defaults[:mock]
-        Excon.defaults[:mock] = true
-        Excon.stub({}, responder)
       end
-
-      after do
-        Excon.defaults[:mock] = @original_mock
-      end
-
       it "sends an empty Host= by default" do
         conn = Excon::Connection.new(
           scheme: "unix",

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -1,0 +1,80 @@
+describe Excon::Connection do
+  include_context('stubs')
+  describe 'validating parameters' do
+    class FooMiddleware < Excon::Middleware::Base
+      def self.valid_parameter_keys
+        [:foo]
+      end
+    end
+
+    let(:foo_stack) do
+      Excon.defaults[:middlewares] + [FooMiddleware]
+    end
+
+    def expect_parameter_warning(validation, key)
+      expect { yield }.to raise_error(Excon::Error::Warning, "Invalid Excon #{validation} keys: #{key.inspect}")
+    end
+
+    context 'with default middleware' do
+      it 'Connection.new warns on invalid parameter keys' do
+        expect_parameter_warning('connection', :foo) do
+          Excon.new('http://foo', :foo => :bar)
+        end
+      end
+
+      it 'Connection#request warns on invalid parameter keys' do
+        conn = Excon.new('http://foo')
+        expect_parameter_warning('request', :foo) do
+          conn.request(:foo => :bar)
+        end
+      end
+    end
+
+    context 'with custom middleware at instantiation' do
+      it 'Connection.new accepts parameters that are valid for the provided middleware' do
+        Excon.new('http://foo', :foo => :bar, :middlewares => foo_stack)
+      end
+
+      it 'Connection.new warns on parameters that are not valid for the provided middleware' do
+        expect_parameter_warning('connection', :bar) do
+          Excon.new('http://foo', :bar => :baz, :middlewares => foo_stack)
+        end
+      end
+
+      it 'Connection#request accepts parameters that are valid for the provided middleware' do
+        Excon.stub({}, {})
+        conn = Excon.new('http://foo', :middlewares => foo_stack)
+        conn.request(:foo => :bar)
+      end
+
+      it 'Connection#request warns on parameters that are not valid for the provided middleware' do
+        conn = Excon.new('http://foo', :middlewares => foo_stack)
+        expect_parameter_warning('request', :bar) do
+          conn.request(:bar => :baz)
+        end
+      end
+    end
+
+    context 'with custom middleware at request time' do
+      it 'Connection#request accepts parameters that are valid for the provided middleware' do
+        Excon.stub({}, {})
+        conn = Excon.new('http://foo')
+        conn.request(:foo => :bar, :middlewares => foo_stack)
+      end
+
+      it 'Connection#request warns on parameters that are not valid for the request middleware' do
+        conn = Excon.new('http://foo')
+        expect_parameter_warning('request', :bar) do
+          conn.request(:bar => :baz, :middlewares => foo_stack)
+        end
+      end
+
+      it 'Connection#request warns on parameters from instantiation that are not valid for the request middleware' do
+        conn = Excon.new('http://foo', :foo => :bar, :middlewares => foo_stack)
+        expect_parameter_warning('connection', :foo) do
+          conn.request(:middlewares => Excon.defaults[:middlewares])
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_contexts/test_stub_context.rb
+++ b/spec/support/shared_contexts/test_stub_context.rb
@@ -1,0 +1,11 @@
+shared_context "stubs" do 
+  before do
+    @original_mock = Excon.defaults[:mock]
+    Excon.defaults[:mock] = true
+  end
+
+  after do
+    Excon.defaults[:mock] = @original_mock
+    Excon.stubs.clear
+  end
+end


### PR DESCRIPTION
This changes the validation logic in Connection to account for which middleware are in the stack as described in #289. I don't think it makes sense to separate out the concepts of `connection` and `request` validations in middleware since they all take place at request time.