### PR TITLE
Ability to configure retriable errors

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -23,11 +23,11 @@ require 'excon/middlewares/instrumentor'
 require 'excon/middlewares/mock'
 require 'excon/middlewares/response_parser'
 
+require 'excon/error'
 require 'excon/constants'
 require 'excon/utils'
 
 require 'excon/connection'
-require 'excon/error'
 require 'excon/headers'
 require 'excon/response'
 require 'excon/middlewares/decompress'

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -109,9 +109,9 @@ module Excon
     :instrumentor_name => 'Instrumentor',
     :mock => 'Mock',
     :retries_remaining => 'Idempotent', # referenced in Instrumentor, but only relevant with Idempotent
-    :retry_limit => 'Idempotent', # referenced in Instrumentor, but only relevant with Idempotent
+    :retry_errors => 'Idempotent',
     :retry_interval => 'Idempotent',
-    :retry_errors => 'Idempotent'
+    :retry_limit => 'Idempotent' # referenced in Instrumentor, but only relevant with Idempotent
   }
 
   unless ::IO.const_defined?(:WaitReadable)
@@ -152,8 +152,8 @@ module Excon
     :omit_default_port    => false,
     :persistent           => false,
     :read_timeout         => 60,
-    :retry_limit          => DEFAULT_RETRY_LIMIT,
     :retry_errors         => DEFAULT_RETRY_ERRORS,
+    :retry_limit          => DEFAULT_RETRY_LIMIT,
     :ssl_verify_peer      => true,
     :ssl_uri_schemes      => [HTTPS],
     :stubs                => :global,

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -14,6 +14,12 @@ module Excon
 
   DEFAULT_RETRY_LIMIT = 4
 
+  DEFAULT_RETRY_ERRORS = [
+    Excon::Error::Timeout,
+    Excon::Error::Socket,
+    Excon::Error::HTTPStatus
+  ]
+
   FORCE_ENC = CR_NL.respond_to?(:force_encoding)
 
   HTTP_1_1 = " HTTP/1.1\r\n"
@@ -104,7 +110,8 @@ module Excon
     :mock => 'Mock',
     :retries_remaining => 'Idempotent', # referenced in Instrumentor, but only relevant with Idempotent
     :retry_limit => 'Idempotent', # referenced in Instrumentor, but only relevant with Idempotent
-    :retry_interval => 'Idempotent'
+    :retry_interval => 'Idempotent',
+    :retry_errors => 'Idempotent'
   }
 
   unless ::IO.const_defined?(:WaitReadable)
@@ -146,6 +153,7 @@ module Excon
     :persistent           => false,
     :read_timeout         => 60,
     :retry_limit          => DEFAULT_RETRY_LIMIT,
+    :retry_errors         => DEFAULT_RETRY_ERRORS,
     :ssl_verify_peer      => true,
     :ssl_uri_schemes      => [HTTPS],
     :stubs                => :global,

--- a/lib/excon/middlewares/idempotent.rb
+++ b/lib/excon/middlewares/idempotent.rb
@@ -9,7 +9,8 @@ module Excon
           :idempotent,
           :retries_remaining,
           :retry_interval,
-          :retry_limit
+          :retry_limit,
+          :retry_errors
         ]
       end
 
@@ -37,8 +38,7 @@ module Excon
           end
         end
 
-        if datum[:idempotent] && [Excon::Error::Timeout, Excon::Error::Socket,
-            Excon::Error::HTTPStatus].any? {|ex| datum[:error].kind_of?(ex) } && datum[:retries_remaining] > 1
+        if datum[:idempotent] && datum[:retry_errors].any? {|ex| datum[:error].kind_of?(ex) } && datum[:retries_remaining] > 1
 
           sleep(datum[:retry_interval]) if datum[:retry_interval]
 

--- a/lib/excon/middlewares/idempotent.rb
+++ b/lib/excon/middlewares/idempotent.rb
@@ -8,9 +8,9 @@ module Excon
         [
           :idempotent,
           :retries_remaining,
+          :retry_errors,
           :retry_interval,
-          :retry_limit,
-          :retry_errors
+          :retry_limit
         ]
       end
 

--- a/lib/excon/middlewares/idempotent.rb
+++ b/lib/excon/middlewares/idempotent.rb
@@ -37,8 +37,8 @@ module Excon
           end
         end
 
-        if datum[:idempotent] && [Excon::Errors::Timeout, Excon::Errors::SocketError,
-            Excon::Errors::HTTPStatusError].any? {|ex| datum[:error].kind_of?(ex) } && datum[:retries_remaining] > 1
+        if datum[:idempotent] && [Excon::Error::Timeout, Excon::Error::Socket,
+            Excon::Error::HTTPStatus].any? {|ex| datum[:error].kind_of?(ex) } && datum[:retries_remaining] > 1
 
           sleep(datum[:retry_interval]) if datum[:retry_interval]
 

--- a/tests/middlewares/idempotent_tests.rb
+++ b/tests/middlewares/idempotent_tests.rb
@@ -191,6 +191,15 @@ Shindo.tests('Excon request idempotencey') do
     response.status
   end
 
+  tests("Overriding default retry_errors").raises(Excon::Error::Socket) do
+    Excon.stub({:method => :get}) { |params|
+      raise Excon::Error::Socket.new(Exception.new "Mock Error")
+    }
+
+    response = @connection.request(:method => :get, :idempotent => true, :retry_errors => [RuntimeError], :path => '/some-path')
+    response.status
+  end
+
   class Block
     attr_reader :rewound
     def initialize

--- a/tests/middlewares/idempotent_tests.rb
+++ b/tests/middlewares/idempotent_tests.rb
@@ -9,12 +9,12 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stubs.clear
   end
 
-  tests("Non-idempotent call with an erroring socket").raises(Excon::Errors::SocketError) do
+  tests("Non-idempotent call with an erroring socket").raises(Excon::Error::Socket) do
     run_count = 0
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 3 # First 3 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -28,7 +28,7 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 3 # First 3 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -38,12 +38,12 @@ Shindo.tests('Excon request idempotencey') do
     response.status
   end
 
-  tests("Idempotent request with socket erroring first 5 times").raises(Excon::Errors::SocketError) do
+  tests("Idempotent request with socket erroring first 5 times").raises(Excon::Error::Socket) do
     run_count = 0
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 5 # First 5 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -58,7 +58,7 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 1 # First call fails.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -68,12 +68,12 @@ Shindo.tests('Excon request idempotencey') do
     response.status
   end
 
-  tests("Lowered retry limit with socket erroring first 3 times").raises(Excon::Errors::SocketError) do
+  tests("Lowered retry limit with socket erroring first 3 times").raises(Excon::Error::Socket) do
     run_count = 0
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 3 # First 3 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -88,7 +88,7 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 5 # First 5 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -98,12 +98,12 @@ Shindo.tests('Excon request idempotencey') do
     response.status
   end
 
-  tests("Raised retry limit with socket erroring first 9 times").raises(Excon::Errors::SocketError) do
+  tests("Raised retry limit with socket erroring first 9 times").raises(Excon::Error::Socket) do
     run_count = 0
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 9 # First 9 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -118,7 +118,7 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 5 # First 5 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -133,7 +133,7 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 2 # First 5 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -145,12 +145,12 @@ Shindo.tests('Excon request idempotencey') do
     response.status
   end
 
-  tests("Retry limit and sleep in constructor with socket erroring first 2 times").raises(Excon::Errors::SocketError) do
+  tests("Retry limit and sleep in constructor with socket erroring first 2 times").raises(Excon::Error::Socket) do
     run_count = 0
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 2 # First 5 calls fail.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -178,7 +178,7 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 1 # First call fails.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end
@@ -193,7 +193,7 @@ Shindo.tests('Excon request idempotencey') do
     Excon.stub({:method => :get}) { |params|
       run_count += 1
       if run_count <= 1 # First call fails.
-        raise Excon::Errors::SocketError.new(Exception.new "Mock Error")
+        raise Excon::Error::Socket.new(Exception.new "Mock Error")
       else
         {:body => params[:body], :headers => params[:headers], :status => 200}
       end


### PR DESCRIPTION
Idempotent middleware retries requests on all http errors. This PR enables `retry_errors` option for configuring specific errors on which it should retry (e.g. only 5xx errors). Ref ticket: https://github.com/excon/excon/issues/689#issuecomment-454534684