### PR TITLE
Ruby 2.6 escapes InvalidURIError output.

### DIFF
--- a/tests/error_tests.rb
+++ b/tests/error_tests.rb
@@ -35,7 +35,7 @@ Shindo.tests('HTTPStatusError request/response debugging') do
       Excon.new('http://localhost', path: "foo\r\nbar: baz")
       false
     rescue => err
-      err.to_s.include? "foo\r\nbar: baz"
+      err.to_s.include?(RUBY_VERSION >= '2.6.0' ? 'foo\r\nbar: baz' : "foo\r\nbar: baz")
     end
   end
 


### PR DESCRIPTION
I observe the following test failure testing against Ruby 2.6:

~~~
  HTTPStatusError request/response debugging
    Excon::Error knows about pertinent errors
    new returns an Error + returns true
    new raises errors for bad URIs + returns true
    new raises errors for bad paths - returns true
      expected => true
      returned => false
    Action? [c,q,r,?]?
~~~

This is apparently caused by https://github.com/ruby/ruby/commit/684cdb4f8340f7a88b00bb91139da74b99ec1147. This PR adds special handling of the output for Ruby 2.6.+