### PR TITLE
Add metadata to the gemspec

### DIFF
--- a/excon.gemspec
+++ b/excon.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('json', '>= 1.8.5')
   s.add_development_dependency('puma')
 
-  spec.metadata = {
+  s.metadata = {
     'homepage_uri'      => 'https://github.com/excon/excon',
     'bug_tracker_uri'   => 'https://github.com/excon/excon/issues',
     'changelog_uri'     => 'https://github.com/excon/excon/blob/master/changelog.txt',

--- a/excon.gemspec
+++ b/excon.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |s|
   spec.metadata = {
     'homepage_uri'      => 'https://github.com/excon/excon',
     'bug_tracker_uri'   => 'https://github.com/excon/excon/issues',
-    'changelog_uri'     => 'https://github.com/excon/excon/blob/master/CHANGES',
-    'documentation_uri' => 'https://github.com/excon/excon/wiki',
+    'changelog_uri'     => 'https://github.com/excon/excon/blob/master/changelog.txt',
+    'documentation_uri' => 'https://github.com/excon/excon/blob/master/README.md',
     'source_code_uri'   => 'https://github.com/excon/excon',
     'wiki_uri'          => 'https://github.com/excon/excon/wiki'
   }

--- a/excon.gemspec
+++ b/excon.gemspec
@@ -26,4 +26,13 @@ Gem::Specification.new do |s|
   s.add_development_dependency('sinatra-contrib')
   s.add_development_dependency('json', '>= 1.8.5')
   s.add_development_dependency('puma')
+
+  spec.metadata = {
+    'homepage_uri'      => 'https://github.com/excon/excon',
+    'bug_tracker_uri'   => 'https://github.com/excon/excon/issues',
+    'changelog_uri'     => 'https://github.com/excon/excon/blob/master/CHANGES',
+    'documentation_uri' => 'https://github.com/excon/excon/wiki',
+    'source_code_uri'   => 'https://github.com/excon/excon',
+    'wiki_uri'          => 'https://github.com/excon/excon/wiki'
+  }
 end


### PR DESCRIPTION
This PR adds some metadata that gets picked up by rubygems.org for those links on the lower right side (though I don't cover all the ones shown here):

![rubygems_links](https://user-images.githubusercontent.com/78529/53735973-786c8c00-3e56-11e9-910f-68f48acf8db4.jpg)
