### PR TITLE
Fix yardoc formatting

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -143,8 +143,8 @@ module Excon
     end
 
     # push an additional stub onto the list to check for mock requests
-    # @param [Hash<Symbol, >] request params to match against, omitted params match all
-    # @param [Hash<Symbol, >] response params to return from matched request or block to call with params
+    # @param request_params [Hash<Symbol, >] request params to match against, omitted params match all
+    # @param response_params [Hash<Symbol, >] response params to return from matched request or block to call with params
     def stub(request_params = {}, response_params = nil)
       if method = request_params.delete(:method)
         request_params[:method] = method.to_s.downcase.to_sym
@@ -187,7 +187,7 @@ module Excon
     end
 
     # get a stub matching params or nil
-    # @param [Hash<Symbol, >] request params to match against, omitted params match all
+    # @param request_params [Hash<Symbol, >] request params to match against, omitted params match all
     # @return [Hash<Symbol, >] response params to return from matched request or block to call with params
     def stub_for(request_params={})
       if method = request_params.delete(:method)
@@ -236,7 +236,7 @@ module Excon
     end
 
     # remove first/oldest stub matching request_params
-    # @param [Hash<Symbol, >] request params to match against, omitted params match all
+    # @param request_params [Hash<Symbol, >] request params to match against, omitted params match all
     # @return [Hash<Symbol, >] response params from deleted stub
     def unstub(request_params = {})
       stub = stub_for(request_params)

--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -113,9 +113,9 @@ module Excon
 
     # @see Connection#initialize
     # Initializes a new keep-alive session for a given remote host
-    #   @param [String] url The destination URL
-    #   @param [Hash<Symbol, >] params One or more option params to set on the Connection instance
-    #   @return [Connection] A new Excon::Connection instance
+    # @param [String] url The destination URL
+    # @param [Hash<Symbol, >] params One or more option params to set on the Connection instance
+    # @return [Connection] A new Excon::Connection instance
     def new(url, params = {})
       uri_parser = params[:uri_parser] || defaults[:uri_parser]
       uri = uri_parser.parse(url)
@@ -143,8 +143,8 @@ module Excon
     end
 
     # push an additional stub onto the list to check for mock requests
-    #   @param [Hash<Symbol, >] request params to match against, omitted params match all
-    #   @param [Hash<Symbol, >] response params to return from matched request or block to call with params
+    # @param [Hash<Symbol, >] request params to match against, omitted params match all
+    # @param [Hash<Symbol, >] response params to return from matched request or block to call with params
     def stub(request_params = {}, response_params = nil)
       if method = request_params.delete(:method)
         request_params[:method] = method.to_s.downcase.to_sym
@@ -187,8 +187,8 @@ module Excon
     end
 
     # get a stub matching params or nil
-    #   @param [Hash<Symbol, >] request params to match against, omitted params match all
-    #   @return [Hash<Symbol, >] response params to return from matched request or block to call with params
+    # @param [Hash<Symbol, >] request params to match against, omitted params match all
+    # @return [Hash<Symbol, >] response params to return from matched request or block to call with params
     def stub_for(request_params={})
       if method = request_params.delete(:method)
         request_params[:method] = method.to_s.downcase.to_sym
@@ -236,8 +236,8 @@ module Excon
     end
 
     # remove first/oldest stub matching request_params
-    #   @param [Hash<Symbol, >] request params to match against, omitted params match all
-    #   @return [Hash<Symbol, >] response params from deleted stub
+    # @param [Hash<Symbol, >] request params to match against, omitted params match all
+    # @return [Hash<Symbol, >] response params from deleted stub
     def unstub(request_params = {})
       stub = stub_for(request_params)
       Excon.stubs.delete_at(Excon.stubs.index(stub))

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -43,22 +43,22 @@ module Excon
     end
 
     # Initializes a new Connection instance
-    #   @param [Hash<Symbol, >] params One or more optional params
-    #     @option params [String] :body Default text to be sent over a socket. Only used if :body absent in Connection#request params
-    #     @option params [Hash<Symbol, String>] :headers The default headers to supply in a request. Only used if params[:headers] is not supplied to Connection#request
-    #     @option params [String] :host The destination host's reachable DNS name or IP, in the form of a String. IPv6 addresses must be wrapped (e.g. [::1]).  See URI#host.
-    #     @option params [String] :hostname Same as host, but usable for socket connections. IPv6 addresses must not be wrapped (e.g. ::1).  See URI#hostname.
-    #     @option params [String] :path Default path; appears after 'scheme://host:port/'. Only used if params[:path] is not supplied to Connection#request
-    #     @option params [Fixnum] :port The port on which to connect, to the destination host
-    #     @option params [Hash]   :query Default query; appended to the 'scheme://host:port/path/' in the form of '?key=value'. Will only be used if params[:query] is not supplied to Connection#request
-    #     @option params [String] :scheme The protocol; 'https' causes OpenSSL to be used
-    #     @option params [String] :socket The path to the unix socket (required for 'unix://' connections)
-    #     @option params [String] :ciphers Only use the specified SSL/TLS cipher suites; use OpenSSL cipher spec format e.g. 'HIGH:!aNULL:!3DES' or 'AES256-SHA:DES-CBC3-SHA'
-    #     @option params [String] :proxy Proxy server; e.g. 'http://myproxy.com:8888'
-    #     @option params [Fixnum] :retry_limit Set how many times we'll retry a failed request.  (Default 4)
-    #     @option params [Fixnum] :retry_interval Set how long to wait between retries. (Default 0)
-    #     @option params [Class] :instrumentor Responds to #instrument as in ActiveSupport::Notifications
-    #     @option params [String] :instrumentor_name Name prefix for #instrument events.  Defaults to 'excon'
+    # @param [Hash<Symbol, >] params One or more optional params
+    # @option params [String] :body Default text to be sent over a socket. Only used if :body absent in Connection#request params
+    # @option params [Hash<Symbol, String>] :headers The default headers to supply in a request. Only used if params[:headers] is not supplied to Connection#request
+    # @option params [String] :host The destination host's reachable DNS name or IP, in the form of a String. IPv6 addresses must be wrapped (e.g. [::1]).  See URI#host.
+    # @option params [String] :hostname Same as host, but usable for socket connections. IPv6 addresses must not be wrapped (e.g. ::1).  See URI#hostname.
+    # @option params [String] :path Default path; appears after 'scheme://host:port/'. Only used if params[:path] is not supplied to Connection#request
+    # @option params [Fixnum] :port The port on which to connect, to the destination host
+    # @option params [Hash]   :query Default query; appended to the 'scheme://host:port/path/' in the form of '?key=value'. Will only be used if params[:query] is not supplied to Connection#request
+    # @option params [String] :scheme The protocol; 'https' causes OpenSSL to be used
+    # @option params [String] :socket The path to the unix socket (required for 'unix://' connections)
+    # @option params [String] :ciphers Only use the specified SSL/TLS cipher suites; use OpenSSL cipher spec format e.g. 'HIGH:!aNULL:!3DES' or 'AES256-SHA:DES-CBC3-SHA'
+    # @option params [String] :proxy Proxy server; e.g. 'http://myproxy.com:8888'
+    # @option params [Fixnum] :retry_limit Set how many times we'll retry a failed request.  (Default 4)
+    # @option params [Fixnum] :retry_interval Set how long to wait between retries. (Default 0)
+    # @option params [Class] :instrumentor Responds to #instrument as in ActiveSupport::Notifications
+    # @option params [String] :instrumentor_name Name prefix for #instrument events.  Defaults to 'excon'
     def initialize(params = {})
       @data = Excon.defaults.dup
       # merge does not deep-dup, so make sure headers is not the original
@@ -221,12 +221,12 @@ module Excon
     end
 
     # Sends the supplied request to the destination host.
-    #   @yield [chunk] @see Response#self.parse
-    #   @param [Hash<Symbol, >] params One or more optional params, override defaults set in Connection.new
-    #     @option params [String] :body text to be sent over a socket
-    #     @option params [Hash<Symbol, String>] :headers The default headers to supply in a request
-    #     @option params [String] :path appears after 'scheme://host:port/'
-    #     @option params [Hash]   :query appended to the 'scheme://host:port/path/' in the form of '?key=value'
+    # @yield [chunk] @see Response#self.parse
+    # @param [Hash<Symbol, >] params One or more optional params, override defaults set in Connection.new
+    # @option params [String] :body text to be sent over a socket
+    # @option params [Hash<Symbol, String>] :headers The default headers to supply in a request
+    # @option params [String] :path appears after 'scheme://host:port/'
+    # @option params [Hash]   :query appended to the 'scheme://host:port/path/' in the form of '?key=value'
     def request(params={}, &block)
       # @data has defaults, merge in new params to override
       datum = @data.merge(params)
@@ -301,7 +301,7 @@ module Excon
     end
 
     # Sends the supplied requests to the destination host using pipelining.
-    #   @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
+    # @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
     def requests(pipeline_params)
       pipeline_params.each {|params| params.merge!(:pipeline => true, :persistent => true) }
       pipeline_params.last.merge!(:persistent => @data[:persistent])
@@ -328,7 +328,7 @@ module Excon
     # Sends the supplied requests to the destination host using pipelining in
     # batches of @limit [Numeric] requests. This is your soft file descriptor
     # limit by default, typically 256.
-    #   @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
+    # @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
     def batch_requests(pipeline_params, limit = nil)
       limit ||= Process.respond_to?(:getrlimit) ? Process.getrlimit(:NOFILE).first : 256
       responses = []

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -301,7 +301,7 @@ module Excon
     end
 
     # Sends the supplied requests to the destination host using pipelining.
-    # @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
+    # @param pipeline_params [Array<Hash>] An array of one or more optional params, override defaults set in Connection.new, see #request for details
     def requests(pipeline_params)
       pipeline_params.each {|params| params.merge!(:pipeline => true, :persistent => true) }
       pipeline_params.last.merge!(:persistent => @data[:persistent])
@@ -328,7 +328,7 @@ module Excon
     # Sends the supplied requests to the destination host using pipelining in
     # batches of @limit [Numeric] requests. This is your soft file descriptor
     # limit by default, typically 256.
-    # @pipeline_params [Array<Hash>] pipeline_params An array of one or more optional params, override defaults set in Connection.new, see #request for details
+    # @param pipeline_params [Array<Hash>] An array of one or more optional params, override defaults set in Connection.new, see #request for details
     def batch_requests(pipeline_params, limit = nil)
       limit ||= Process.respond_to?(:getrlimit) ? Process.getrlimit(:NOFILE).first : 256
       responses = []

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -222,7 +222,7 @@ module Excon
     end
 
     # Retrieve a specific header value. Header names are treated case-insensitively.
-    #   @param [String] name Header name
+    # @param [String] name Header name
     def get_header(name)
       headers[name]
     end


### PR DESCRIPTION
Fixes #698 

Yardoc does not seem to like the extra indentation and fails to render the params and option hash documentation correctly.

With that fixed, yardoc gives a few warnings:

```
[warn]: @param tag has unknown parameter name: request
    in file `lib/excon.rb' near line 148
[warn]: @param tag has unknown parameter name: response
    in file `lib/excon.rb' near line 148
[warn]: @param tag has unknown parameter name: request
    in file `lib/excon.rb' near line 192
[warn]: @param tag has unknown parameter name: request
    in file `lib/excon.rb' near line 241
[warn]: Unknown tag @pipeline_params in file `lib/excon/connection.rb` near line 305
[warn]: Unknown tag @pipeline_params in file `lib/excon/connection.rb` near line 332
```

These were fixed and now yardoc runs cleanly:

```
$ bundle exec yardoc
Files:          30
Modules:        14 (   12 undocumented)
Classes:        80 (   34 undocumented)
Constants:      33 (   27 undocumented)
Attributes:     14 (    0 undocumented)
Methods:       142 (  106 undocumented)
 36.75% documented
```

# Before:

![image](https://user-images.githubusercontent.com/224971/57608787-4e31fb80-7576-11e9-9a4f-ef0e6a827f1a.png)


------------------------------------


# After:

![image](https://user-images.githubusercontent.com/224971/57608869-7de10380-7576-11e9-9bb6-64054f8de503.png)



