### PR TITLE
fix creating a Proc without a block

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -145,7 +145,7 @@ module Excon
     # push an additional stub onto the list to check for mock requests
     # @param request_params [Hash<Symbol, >] request params to match against, omitted params match all
     # @param response_params [Hash<Symbol, >] response params to return from matched request or block to call with params
-    def stub(request_params = {}, response_params = nil)
+    def stub(request_params = {}, response_params = nil, &block)
       if method = request_params.delete(:method)
         request_params[:method] = method.to_s.downcase.to_sym
       end
@@ -175,7 +175,7 @@ module Excon
         if response_params
           raise(ArgumentError.new("stub requires either response_params OR a block"))
         else
-          stub = [request_params, Proc.new]
+          stub = [request_params, block]
         end
       elsif response_params
         stub = [request_params, response_params]

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -257,7 +257,7 @@ module Excon
 
       if block_given?
         Excon.display_warning('Excon requests with a block are deprecated, pass :response_block instead.')
-        datum[:response_block] = Proc.new
+        datum[:response_block] = block
       end
 
       datum[:connection] = self


### PR DESCRIPTION
fixes
`
    /excon-0.64.0/lib/excon.rb:178: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
`

refs https://github.com/ruby/ruby/commit/9f1fb0a17feb