### PR TITLE
fixed response status check when making a request with a valid proxy …

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -108,7 +108,7 @@ module Excon
 
         # eat the proxy's connection response
         response = Excon::Response.parse(self,  :expects => 200, :method => 'CONNECT')
-        if response[:status] != 200
+        if response[:response][:status] != 200
           raise(Excon::Errors::ProxyConnectionError.new("proxy connection is not exstablished"))
         end
       end


### PR DESCRIPTION
All calls raise Excon::Errors::ProxyConnectionError when making a call with http_proxy or https_proxy set to a valid address in the environment.

It looks like the issue is that status is a subkey of response and not at the root of the hash:
```
{:expects=>200, :method=>"CONNECT", :response=>{:body=>"", :cookies=>[], :host=>nil, :headers=>{}, :path=>nil, :port=>nil, :status=>200, :status_line=>"HTTP/1.1 200 Connection established\r\n", :reason_phrase=>"Connection established", :remote_ip=>"[IP]", :local_port=>[PORT], :local_address=>"[IP]"}}
```