### PR TITLE
Use String#dup in Excon::Utils#binary_encode for frozen string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - ruby-head
 script:
   - "bundle exec shindont"
   - "bundle exec rake spec[progress]"
 sudo: false
+
+matrix:
+  allow_failures:
+  - rvm: ruby-head

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -161,7 +161,7 @@ module Excon
             socket.write(request) # write out request + headers
             while true # write out body with chunked encoding
               chunk = datum[:request_block].call
-              binary_encode(chunk)
+              chunk = binary_encode(chunk)
               if chunk.length > 0
                 socket.write(chunk.length.to_s(16) << CR_NL << chunk << CR_NL)
               else
@@ -180,10 +180,10 @@ module Excon
             end
 
             # if request + headers is less than chunk size, fill with body
-            binary_encode(request)
+            request = binary_encode(request)
             chunk = body.read([datum[:chunk_size] - request.length, 0].max)
             if chunk
-              binary_encode(chunk)
+              chunk = binary_encode(chunk)
               socket.write(request << chunk)
             else
               socket.write(request) # write out request + headers

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -237,7 +237,7 @@ module Excon
     end
 
     def write_nonblock(data)
-      binary_encode(data)
+      data = binary_encode(data)
       loop do
         written = nil
         begin

--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -12,7 +12,13 @@ module Excon
 
     def binary_encode(string)
       if FORCE_ENC && string.encoding != Encoding::ASCII_8BIT
-        string.force_encoding('BINARY')
+        if string.frozen?
+          string.dup.force_encoding('BINARY')
+        else
+          string.force_encoding('BINARY')
+        end
+      else
+        string
       end
     end
 
@@ -89,7 +95,7 @@ module Excon
     def split_header_value(str)
       return [] if str.nil?
       str = str.dup.strip
-      binary_encode(str)
+      str = binary_encode(str)
       str.scan(%r'\G((?:"(?:\\.|[^"])+?"|[^",]+)+)
                     (?:,\s*|\Z)'xn).flatten
     end
@@ -97,21 +103,21 @@ module Excon
     # Escapes HTTP reserved and unwise characters in +str+
     def escape_uri(str)
       str = str.dup
-      binary_encode(str)
+      str = binary_encode(str)
       str.gsub(UNESCAPED) { "%%%02X" % $1[0].ord }
     end
 
     # Unescapes HTTP reserved and unwise characters in +str+
     def unescape_uri(str)
       str = str.dup
-      binary_encode(str)
+      str = binary_encode(str)
       str.gsub(ESCAPED) { $1.hex.chr }
     end
 
     # Unescape form encoded values in +str+
     def unescape_form(str)
       str = str.dup
-      binary_encode(str)
+      str = binary_encode(str)
       str.gsub!(/\+/, ' ')
       str.gsub(ESCAPED) { $1.hex.chr }
     end


### PR DESCRIPTION
Hi, I'm Itamae gem maintainer.
https://github.com/itamae-kitchen/itamae

## probrem
I found itamae gem's CI failing on ruby-head (it will release as Ruby 2.7).
I investigated about that reason.
CI failing by excon called from docker-api gem.
https://travis-ci.org/itamae-kitchen/itamae/builds/625473573

```
11: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/docker-api-1.34.2/lib/docker/connection.rb:40:in `request'
10: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/connection.rb:275:in `request'
 9: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/middlewares/base.rb:22:in `request_call'
 8: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/middlewares/base.rb:22:in `request_call'
 7: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/middlewares/base.rb:22:in `request_call'
 6: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/middlewares/idempotent.rb:19:in `request_call'
 5: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/middlewares/instrumentor.rb:34:in `request_call'
 4: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/middlewares/mock.rb:57:in `request_call'
 3: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/middlewares/redirect_follower.rb:15:in `request_call'
 2: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/connection.rb:164:in `request_call'
 1: from /home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/utils.rb:15:in `binary_encode'
/home/travis/build/itamae-kitchen/itamae/vendor/bundle/ruby/2.7.0/gems/excon-0.71.0/lib/excon/utils.rb:15:in `force_encoding': can't modify frozen String: "" (FrozenError) (Excon::Error::Socket)
```

## solution
Therefore, use `String#dup` in `Excon::Utils#binary_encode` for frozen string literal, and caller assign returned duplicated string to a variable.

![Screenshot from 2019-12-18 17-56-49](https://user-images.githubusercontent.com/4487291/71071352-ce30db80-21bf-11ea-8bdf-b60a8d09ab18.png)
https://travis-ci.org/itamae-kitchen/itamae/builds/626589627
