### PR TITLE
embed response from proxy in ProxyConnectionError

### DIFF
--- a/lib/excon/error.rb
+++ b/lib/excon/error.rb
@@ -52,11 +52,12 @@ or:
     class ResponseParse < Error; end
 
     class ProxyConnectionError < Error
-      attr_reader :proxy_response
+      attr_reader :request, :response
 
-      def initialize(msg, proxy_response = nil)
+      def initialize(msg, request = nil, response = nil)
         super(msg)
-        @proxy_response = proxy_response
+        @request = request
+        @response = response
       end
     end
 

--- a/lib/excon/error.rb
+++ b/lib/excon/error.rb
@@ -50,7 +50,16 @@ or:
     class InvalidHeaderValue < Error; end
     class Timeout < Error; end
     class ResponseParse < Error; end
-    class ProxyConnectionError < Error; end
+
+    class ProxyConnectionError < Error
+      attr_reader :proxy_response
+
+      def initialize(msg, proxy_response = nil)
+        super(msg)
+        @proxy_response = proxy_response
+      end
+    end
+
     class ProxyParse < Error; end
     class TooManyRedirects < Error; end
 

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -109,7 +109,7 @@ module Excon
         # eat the proxy's connection response
         response = Excon::Response.parse(self,  :expects => 200, :method => 'CONNECT')
         if response[:response][:status] != 200
-          raise(Excon::Errors::ProxyConnectionError.new("proxy connection could not be established", response))
+          raise(Excon::Errors::ProxyConnectionError.new("proxy connection could not be established", request, response))
         end
       end
 

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -109,7 +109,7 @@ module Excon
         # eat the proxy's connection response
         response = Excon::Response.parse(self,  :expects => 200, :method => 'CONNECT')
         if response[:response][:status] != 200
-          raise(Excon::Errors::ProxyConnectionError.new("proxy connection is not exstablished"))
+          raise(Excon::Errors::ProxyConnectionError.new("proxy connection could not be established", response))
         end
       end
 


### PR DESCRIPTION
This PR extends `ProxyConnectionError` to include the CONNECT response from the proxy. Doing so allows clients to better understand the cause of the proxy failure. 

This closes #714.