### PR TITLE
Add ip-address handling to no_proxy-envvar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
       sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
     fi
+  - rm -f Gemfile.lock >/dev/null
 cache: bundler
 language: ruby
 rvm:

--- a/tests/proxy_tests.rb
+++ b/tests/proxy_tests.rb
@@ -151,7 +151,7 @@ Shindo.tests('Excon proxy support') do
       env = {
         'http_proxy' => 'http://myproxy:8080',
         'https_proxy' => 'http://mysecureproxy:8081',
-        'no_proxy' => 'noproxy, subdomain.noproxy2'
+        'no_proxy' => 'noproxy, subdomain.noproxy2, [fc00::1], 10.0.0.1'
       }
       tests('lowercase') { env_proxy_tests(env) }
       upperenv = {}


### PR DESCRIPTION
I did add handling for host IP-addresses. This should also give the ability to specify network-addreses like `10.0.0.0/8` or `[fc00::/7]`in the `no_proxy` variable.
However, they will only be evaluated correctly if the requested URI also includes the IP-address.

Added an IPv4 and IPv6 address to the `no_proxy` variable in the tests, so they will fail, if this breaks again.
Maybe additional test-cases are needed regarding the no_proxy handling like

- IP-address (maybe IP network-address)
- no_proxy entries with specified hostname
- no_proxy entries with/without wildcards

Fixes #716