### PR TITLE
Explicitly require IPAddr

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'ipaddr'
+
 module Excon
   class Connection
     include Utils


### PR DESCRIPTION
In [0.74.0](https://github.com/excon/excon/releases/tag/v0.74.0), https://github.com/excon/excon/pull/718 was shipped, which introduced a [dependency on `IPAddr`](https://github.com/excon/excon/pull/718/files#diff-93618fc68cdc1fde818cf4abd7102a14R495).

This dependency has been [transitively loaded by `openssl`](https://github.com/ruby/openssl/blob/0aaf274211d4b4877b266bc1ad406db4fd8160ab/lib/openssl/ssl.rb#L15) since [2.2.0](https://github.com/ruby/openssl/commit/5c5bf71394b286698956438a3694b71640d6895b), released [May 13, 2020](https://rubygems.org/gems/openssl/versions/2.2.0), which [`excon` always loads](https://github.com/excon/excon/blob/f6a6e780d3c29e17ad490c7f88d4761f0899b0b5/lib/excon.rb#L7
). This means that Ruby installations using a version of `openssl` from before May 13, 2020 can be missing loading `ipaddr`.

This PR adds that explicitly dependency to the relevant file: `lib/excon/connection.rb`.

One thing I'm still not sure is why travis-ci is not failing for Ruby 2.3, given I can reliably reproduce it as follows:

## Steps to reproduce
```
$ docker run -it ruby:2.3.8 bash
```

Then inside the container:

```
$ git clone https://github.com/excon/excon.git
$ cd excon/
$ bundle install
$ bundle exec shindont
```
I'm seeing the following error:
```
  Excon proxy support +++++++++
            tests/proxy_tests.rb
            uninitialized constant Excon::Connection::IPAddr (NameError)
              /excon/lib/excon/connection.rb:516:in `rescue in block in proxy_from_env'
```