### PR TITLE
Excon::Socket.readline to use buffered reads

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -60,18 +60,8 @@ module Excon
     def readline
       return legacy_readline if RUBY_VERSION.to_f <= 1.8_7
       buffer = String.new
-      begin
-        buffer << @socket.read_nonblock(1) while buffer[-1] != "\n"
-        buffer
-      rescue *READ_RETRY_EXCEPTION_CLASSES
-        select_with_timeout(@socket, :read) && retry
-      rescue OpenSSL::SSL::SSLError => error
-        if error.message == 'read would block'
-          select_with_timeout(@socket, :read) && retry
-        else
-          raise(error)
-        end
-      end
+      buffer << read_nonblock(1) while buffer[-1] != "\n"
+      buffer
     end
 
     def legacy_readline


### PR DESCRIPTION
`Excon::Socket.readline` currently reads 1 byte at a time,
by performing one syscall for each byte (through `::Socket::read_nonblock`).
This change proposes to use the private `Excon::Socket.read_nonblock` primitive
instead, to benefit from the read buffer.

Tests & specs seem to run fine with this change.