### PR TITLE
Support ssl_verify_hostname parameter to use OpenSSL::SSL::SSLContext#verify_hostname=

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -95,6 +95,7 @@ module Excon
     :ssl_verify_callback,
     :ssl_verify_peer,
     :ssl_verify_peer_host,
+    :ssl_verify_hostname,
     :ssl_version,
     :ssl_min_version,
     :ssl_max_version,

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -73,6 +73,9 @@ module Excon
         ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
 
+      # Verify certificate hostname if supported (ruby >= 2.4.0)
+      ssl_context.verify_hostname = @data[:ssl_verify_hostname] if ssl_context.respond_to?(:verify_hostname=)
+
       if client_cert_data && client_key_data
         ssl_context.cert = OpenSSL::X509::Certificate.new client_cert_data
         if OpenSSL::PKey.respond_to? :read

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -138,6 +138,23 @@ Shindo.tests('Excon basics (ssl)') do
   end
 end
 
+Shindo.tests('Excon basics verify_hostname (ssl)') do
+  with_rackup('ssl.ru') do
+    connection = nil
+    test do
+      ssl_ca_file = File.join(File.dirname(__FILE__), 'data', '127.0.0.1.cert.crt')
+      connection = Excon.new('https://127.0.0.1:9443', :ssl_verify_peer => true, :ssl_ca_file => ssl_ca_file, :ssl_verify_hostname => true )
+      true
+    end
+
+    tests('response.status').returns(200) do
+      response = connection.request(:method => :get, :path => '/content-length/100')
+
+      response.status
+    end
+  end
+end
+
 Shindo.tests('Excon ssl verify peer (ssl)') do
   with_rackup('ssl.ru') do
     connection = nil


### PR DESCRIPTION
Currerntly, `Excon` does not handle `OpenSSL::SSL::SSLContext#verify_hostname=` method on `Excon::SSLSocket` class and does not provide way to handle whether handling [`verify_hostname` option in ruby openssl](https://github.com/ruby/ruby/pull/2858) or not.
Is this planned feature?

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>