### PR TITLE
Make Host header be always the first in requests

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -252,6 +252,8 @@ module Excon
         datum[:headers]['Host']   ||= datum[:host] + port_string(datum)
       end
 
+      # RFC 7230, section 5.4, states that the Host header SHOULD be the first one # to be present.
+      # Some web servers will reject the request if it comes too late, so let's hoist it to the top.
       if host = datum[:headers].delete('Host')
         datum[:headers] = { 'Host' => host }.merge(datum[:headers])
       end

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -252,6 +252,10 @@ module Excon
         datum[:headers]['Host']   ||= datum[:host] + port_string(datum)
       end
 
+      if host = datum[:headers].delete('Host')
+        datum[:headers] = { 'Host' => host }.merge(datum[:headers])
+      end
+
       # if path is empty or doesn't start with '/', insert one
       unless datum[:path][0, 1] == '/'
         datum[:path] = datum[:path].dup.insert(0, '/')

--- a/tests/request_headers_tests.rb
+++ b/tests/request_headers_tests.rb
@@ -16,6 +16,14 @@ Shindo.tests('Excon request methods') do
 
     end
 
+    tests('header order') do
+      tests('host is the first sent header by default').returns('host: localhost:9292') do
+        response = Excon.post('http://localhost:9292/')
+
+        response.body.lines.first.chomp
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
I observed that some servers (Cloudflare, for instance) will fail the request or will respond with redirects to the same URL if the Host header comes too late in the request.

I think this actually make sense from a security perspective, as having Host late in the request would mean a server with virtual hosts would have to buffer everything before the Host header before deciding where the request will land and whether the virtual host is even valid.

[RFC 7230 section 5.4](https://tools.ietf.org/html/rfc7230#section-5.4) supports this, stating that:

> Since the Host field-value is critical information for handling a
> request, a user agent SHOULD generate Host as the first header field
> following the request-line.

I propose here this changes that always lifts the Host header to be the first one sent. By looking at the previous lines, the `if` condition shouldn't alter semantics as I don't see how `datum[:headers]['Host']` could be `nil`.

What do you think? Happy to discuss solutions.

Would be also nice if someone could point me into which file I could add tests/specs :) 
