### PR TITLE
Improve instrumentor for  logging errors

### DIFF
--- a/lib/excon/middlewares/instrumentor.rb
+++ b/lib/excon/middlewares/instrumentor.rb
@@ -12,7 +12,7 @@ module Excon
 
       def error_call(datum)
         if datum.has_key?(:instrumentor)
-          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.error", :error => datum[:error]) do
+          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.error", :error => datum[:error], **(datum[:response] || {})) do
             @stack.error_call(datum)
           end
         else


### PR DESCRIPTION
I added request body and headers to instrumentor for `error_call`. 

This give possibility debug response bodies, when recieve unexpected errors. 