### PR TITLE
Do not use explicit hash for options.

### DIFF
--- a/tests/rackups/ssl.ru
+++ b/tests/rackups/ssl.ru
@@ -6,11 +6,11 @@ require File.join(File.dirname(__FILE__), 'basic')
 
 key_file = File.join(File.dirname(__FILE__), '..', 'data', '127.0.0.1.cert.key')
 cert_file = File.join(File.dirname(__FILE__), '..', 'data', '127.0.0.1.cert.crt')
-Rack::Handler::WEBrick.run(Basic, {
+Rack::Handler::WEBrick.run(Basic,
   :Port             => 9443,
   :SSLEnable        => true,
   :SSLPrivateKey    => OpenSSL::PKey::RSA.new(File.open(key_file).read),
   :SSLCertificate   => OpenSSL::X509::Certificate.new(File.open(cert_file).read),
   :SSLCACertificateFile => cert_file,
   :SSLVerifyClient  => OpenSSL::SSL::VERIFY_NONE,
-})
+)

--- a/tests/rackups/ssl_mismatched_cn.ru
+++ b/tests/rackups/ssl_mismatched_cn.ru
@@ -5,11 +5,11 @@ require 'webrick/https'
 require File.join(File.dirname(__FILE__), 'basic')
 key_file = File.join(File.dirname(__FILE__), '..', 'data', 'excon.cert.key')
 cert_file = File.join(File.dirname(__FILE__), '..', 'data', 'excon.cert.crt')
-Rack::Handler::WEBrick.run(Basic, {
+Rack::Handler::WEBrick.run(Basic,
   :Port             => 9443,
   :SSLEnable        => true,
   :SSLPrivateKey    => OpenSSL::PKey::RSA.new(File.open(key_file).read),
   :SSLCertificate   => OpenSSL::X509::Certificate.new(File.open(cert_file).read),
   :SSLCACertificateFile => cert_file,
   :SSLVerifyClient  => OpenSSL::SSL::VERIFY_NONE,
-})
+)

--- a/tests/rackups/ssl_verify_peer.ru
+++ b/tests/rackups/ssl_verify_peer.ru
@@ -5,7 +5,7 @@ require 'webrick/https'
 require File.join(File.dirname(__FILE__), 'basic')
 key_file = File.join(File.dirname(__FILE__), '..', 'data', 'excon.cert.key')
 cert_file = File.join(File.dirname(__FILE__), '..', 'data', 'excon.cert.crt')
-Rack::Handler::WEBrick.run(Basic, {
+Rack::Handler::WEBrick.run(Basic,
   :Port             => 8443,
   :SSLCertName      => [["CN", WEBrick::Utils::getservername]],
   :SSLEnable        => true,
@@ -13,4 +13,4 @@ Rack::Handler::WEBrick.run(Basic, {
   :SSLCertificate => OpenSSL::X509::Certificate.new(File.open(cert_file).read),
   :SSLCACertificateFile => cert_file,
   :SSLVerifyClient  => OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT,
-})
+)


### PR DESCRIPTION
This should ensure compatibility with Rack 2.2+, which assumes that options might be passed as kwargs:

https://github.com/rack/rack/commit/871c82f0ffa269d7e2e237d3ade9a1eac26418fe

This is related to #733