### PR TITLE
[WIP] Add '-d' option for rackup to debug the Ruby 3.0 test failures.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0']
     continue-on-error: ${{ matrix.ruby == '3.0' }}
 
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'jruby-openssl', '~> 0.10.5', :platforms => :jruby
 gem 'unicorn', :platforms => [:mri, :rbx], :groups => [:development, :test]
-gem 'rubysl', '~> 2.2.0', :platforms => :rbx
+#gem 'rubysl', '~> 2.2.0', :platforms => :rbx
 gem 'rack', '>= 2.2.3'
 gem 'rubocop'
 

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -245,7 +245,7 @@ def rackup_path(*parts)
 end
 
 def with_rackup(name, host="127.0.0.1")
-  pid, w, r, e = launch_process("rackup", "-s", "webrick", "--host", host, rackup_path(name))
+  pid, w, r, e = launch_process("rackup", "-d", "-s", "webrick", "--host", host, rackup_path(name))
   until e.gets =~ /HTTPServer#start:/; end
   yield
 ensure


### PR DESCRIPTION
This is not intended to be merged. This servers to debug the Ruby 3.0 issues, because the GH actions fails and I observe similar issues on Fedora. Trying to dig into this, this is part of the output I was able to get:

~~~
/usr/share/ruby/openssl/buffering.rb:80: [BUG] during_gc != 0
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux]
-- Control frame information -----------------------------------------------
c:0014 p:---- s:0103 e:000102 CFUNC  :sysread
c:0013 p:0015 s:0098 e:000096 METHOD /usr/share/ruby/openssl/buffering.rb:80
c:0012 p:0057 s:0093 e:000092 METHOD /usr/share/ruby/openssl/buffering.rb:121
c:0011 p:0011 s:0086 e:000085 BLOCK  /usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:565
c:0010 p:0051 s:0083 e:000082 METHOD /usr/share/gems/gems/webrick-1.7.0/lib/webrick/utils.rb:258
c:0009 p:0023 s:0076 e:000075 METHOD /usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:564
c:0008 p:0009 s:0069 e:000068 METHOD /usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:579
c:0007 p:0127 s:0063 e:000062 METHOD /usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:518
c:0006 p:0034 s:0054 E:002228 METHOD /usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:257
c:0005 p:0033 s:0049 e:000047 METHOD /usr/share/gems/gems/rack-2.2.3/lib/rack/handler/webrick.rb:71
c:0004 p:0189 s:0032 e:000031 METHOD /usr/share/gems/gems/webrick-1.7.0/lib/webrick/httpserver.rb:140
c:0003 p:0256 s:0021 e:000020 METHOD /usr/share/gems/gems/webrick-1.7.0/lib/webrick/httpserver.rb:96
c:0002 p:0136 s:0009 e:000008 BLOCK  /usr/share/gems/gems/webrick-1.7.0/lib/webrick/server.rb:310 [FINISH]
c:0001 p:---- s:0003 e:000002 (none) [FINISH]
-- Ruby level backtrace information ----------------------------------------
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/server.rb:310:in `block in start_thread'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/httpserver.rb:96:in `run'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/httpserver.rb:140:in `service'
/usr/share/gems/gems/rack-2.2.3/lib/rack/handler/webrick.rb:71:in `service'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:257:in `body'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:518:in `read_body'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:579:in `read_data'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:564:in `_read_data'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/utils.rb:258:in `timeout'
/usr/share/gems/gems/webrick-1.7.0/lib/webrick/httprequest.rb:565:in `block in _read_data'
/usr/share/ruby/openssl/buffering.rb:121:in `read'
/usr/share/ruby/openssl/buffering.rb:80:in `fill_rbuff'
/usr/share/ruby/openssl/buffering.rb:80:in `sysread'
-- C level backtrace information -------------------------------------------
/lib64/libruby.so.3.0(0x7f96979f6e0a) [0x7f96979f6e0a]
/lib64/libruby.so.3.0(0x7f969784bbf6) [0x7f969784bbf6]
/lib64/libruby.so.3.0(rb_bug+0xa1) [0x7f96977d775b]
/lib64/libruby.so.3.0(0x7f96977d7fc4) [0x7f96977d7fc4]
/lib64/libruby.so.3.0(0x7f969786f05e) [0x7f969786f05e]
/lib64/libruby.so.3.0(0x7f969786f113) [0x7f969786f113]
/lib64/libruby.so.3.0(0x7f96979314ff) [0x7f96979314ff]
/lib64/libruby.so.3.0(0x7f9697870885) [0x7f9697870885]
/lib64/libruby.so.3.0(0x7f969786ec0b) [0x7f969786ec0b]
/lib64/libruby.so.3.0(0x7f969786f05e) [0x7f969786f05e]
/lib64/libruby.so.3.0(0x7f969786f223) [0x7f969786f223]
/lib64/libruby.so.3.0(0x7f969797fd2d) [0x7f969797fd2d]
/usr/lib64/ruby/openssl.so(0x7f9693d80589) [0x7f9693d80589]
/lib64/libruby.so.3.0(0x7f96979db1d5) [0x7f96979db1d5]
/lib64/libruby.so.3.0(0x7f96979dd536) [0x7f96979dd536]
/lib64/libruby.so.3.0(0x7f96979e01d2) [0x7f96979e01d2]
/lib64/libruby.so.3.0(rb_vm_exec+0x115) [0x7f96979e5555]
/lib64/libruby.so.3.0(rb_vm_invoke_proc+0x5f) [0x7f96979ea30f]
/lib64/libruby.so.3.0(0x7f96979a7ca9) [0x7f96979a7ca9]
/lib64/libruby.so.3.0(0x7f96979a82e3) [0x7f96979a82e3]
/lib64/libruby.so.3.0(0x7f96979a8a9d) [0x7f96979a8a9d]
/lib64/libpthread.so.0(start_thread+0xe9) [0x7f969759f1c9]
/lib64/libc.so.6(clone+0x43) [0x7f96976d1473]
-- Other runtime information -----------------------------------------------

... snip ...
~~~

Now trying to reproduce upstream.