### PR TITLE
Raise EOFError in Socket#readline instead of TypeError

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -60,7 +60,7 @@ module Excon
     def readline
       return legacy_readline if RUBY_VERSION.to_f <= 1.8_7
       buffer = String.new
-      buffer << read_nonblock(1) while buffer[-1] != "\n"
+      buffer << (read_nonblock(1) || raise(EOFError)) while buffer[-1] != "\n"
       buffer
     end
 


### PR DESCRIPTION
Before this patch the following error would be raised which could be
confusing:

```
Excon::Error::Socket: no implicit conversion of nil into String (TypeError)
```

Due to: `"" < nil`