### PR TITLE
Handle Case When Proxy key exists but is set to nil

### DIFF
--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -50,7 +50,7 @@ module Excon
       if datum.has_key?(:password)
         datum[:password] = REDACTED
       end
-      if datum.has_key?(:proxy) && datum[:proxy].has_key?(:password)
+      if datum.has_key?(:proxy) && datum[:proxy]&.has_key?(:password)
         datum[:proxy] = datum[:proxy].dup
         datum[:proxy][:password] = REDACTED
       end


### PR DESCRIPTION
In testing related to using the libhoney-rb gem (via beeline-ruby) in an rspec suite, I discovered that there was a case where the `Proxy` key of `datum` is being added, but with a value of `nil`, causing the redact method to throw a nil method error. Adding this safe navigation should better handle that case.