### PR TITLE
Adjust the datum[proxy] for <2.3

### DIFF
--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -50,7 +50,7 @@ module Excon
       if datum.has_key?(:password)
         datum[:password] = REDACTED
       end
-      if datum.has_key?(:proxy) && datum[:proxy]&.has_key?(:password)
+      if datum.has_key?(:proxy) && datum[:proxy] && datum[:proxy].has_key?(:password)
         datum[:proxy] = datum[:proxy].dup
         datum[:proxy][:password] = REDACTED
       end


### PR DESCRIPTION
The previous change uses the "Safe Navigation Operator" (&.), which is a new feature in 2.3, thus making 0.80.0 unusable by people who might have to use Ruby <2.3