### PR TITLE
allow to use Syslog::Logger

### DIFF
--- a/lib/excon/instrumentors/logging_instrumentor.rb
+++ b/lib/excon/instrumentors/logging_instrumentor.rb
@@ -40,7 +40,7 @@ module Excon
         end
       end
 
-      logger.log(Logger::INFO, info) if info
+      logger.info(info) if info
 
       yield if block_given?
     end


### PR DESCRIPTION
https://ruby-doc.org/stdlib-2.6.3/libdoc/syslog/rdoc/Syslog/Logger.html has no `log` method defined, but `add` defined
https://ruby-doc.org/stdlib-2.6.3/libdoc/logger/rdoc/Logger.html has `log` method as alias for `add`


both loggers  have shortcut `info`  method