### PR TITLE
Add ssl_security_level support

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -99,6 +99,7 @@ module Excon
     :ssl_version,
     :ssl_min_version,
     :ssl_max_version,
+    :ssl_security_level,
     :ssl_proxy_headers,
     :ssl_uri_schemes,
     :tcp_nodelay,

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -12,6 +12,11 @@ module Excon
       # create ssl context
       ssl_context = OpenSSL::SSL::SSLContext.new
 
+      # set the security level before setting other parameters affected by it
+      if @data[:ssl_security_level]
+        ssl_context.security_level = @data[:ssl_security_level]
+      end
+
       # disable less secure options, when supported
       ssl_context_options = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options]
       if defined?(OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS)


### PR DESCRIPTION
This change adds an `:ssl_security_level` option to change the security level of the `SSLContext` before Excon uses it to create an `SSLSocket`.

OpenSSL 1.1.0 introduced security levels, where increasingly large security levels forbid increasingly strong cryptographic algorithms and parameters.  Security level 0 forbids nothing (the default behavior in previous versions of OpenSSL), and security level 5 allows only very strong algorithms and very long key lengths.

Every OpenSSL library now has a default security level compiled into it, and programs may need to change the security level from its default.

Changing an `OpenSSL::SSL::SSLContext`'s security level requires Ruby 2.4.0+ or version 2.0.0+ of the `openssl` gem.  See the following for more information:

- https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-security_level-3D
- https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_security_level.html