### PR TITLE
[bugfix] Overwrite socket data if already initialized

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -115,7 +115,7 @@ module Excon
           # we already have data from a middleware, so bail
           return datum
         else
-          socket(datum)
+          socket(datum).data = datum
           # start with "METHOD /path"
           request = datum[:method].to_s.upcase + ' '
           if datum[:proxy] && datum[:scheme] != HTTPS


### PR DESCRIPTION
Turns out I introduced a bug in #742 🙈 

We're reusing the socket in one of our middlewares and noticed that the new `datum` passed in the request wasn't being written to the existing `socket`s datum. This line used to be `socket.data = datum` and currently with just `socket(datum)`, it only uses the `datum` when initializing the socket, which breaks the previous behaviour of overwriting on an existing socket.

This patch should fix that, while also keeping the desired behaviour from #742 