### PR TITLE
Prevent test suite lockups on test server failure

### DIFF
--- a/lib/excon/test/plugin/server/exec.rb
+++ b/lib/excon/test/plugin/server/exec.rb
@@ -4,10 +4,13 @@ module Excon
       module Server
         module Exec
           def start(app_str = app)
-            line = ''
             open_process(app_str)
+            process_stderr = ""
+            line = ''
             until line =~ /\Aready\Z/
               line = error.gets
+              raise process_stderr if line.nil?
+              process_stderr << line
               fatal_time = elapsed_time > timeout
               if fatal_time
                 msg = "executable #{app_str} has taken too long to start"

--- a/lib/excon/test/plugin/server/puma.rb
+++ b/lib/excon/test/plugin/server/puma.rb
@@ -5,9 +5,12 @@ module Excon
         module Puma
           def start(app_str = app, bind_uri = bind)
             open_process('puma', '-b', bind_uri.to_s, app_str)
+            process_stderr = ""
             line = ''
             until line =~ /Use Ctrl-C to stop/
               line = read.gets
+              raise process_stderr if line.nil?
+              process_stderr << line
               fatal_time = elapsed_time > timeout
               raise 'puma server has taken too long to start' if fatal_time
             end

--- a/lib/excon/test/plugin/server/unicorn.rb
+++ b/lib/excon/test/plugin/server/unicorn.rb
@@ -20,9 +20,12 @@ module Excon
               app_str
             ]
             open_process(*args)
+            process_stderr = ''
             line = ''
             until line =~ /worker\=0 ready/
               line = error.gets
+              raise process_stderr if line.nil?
+              process_stderr << line
               fatal_time = elapsed_time > timeout
               raise 'unicorn server has taken too long to start' if fatal_time
             end

--- a/lib/excon/test/plugin/server/webrick.rb
+++ b/lib/excon/test/plugin/server/webrick.rb
@@ -8,9 +8,12 @@ module Excon
             host = bind_uri.host.gsub(/[\[\]]/, '')
             port = bind_uri.port.to_s
             open_process('rackup', '-s', 'webrick', '--host', host, '--port', port, app_str)
+            process_stderr = ""
             line = ''
             until line =~ /HTTPServer#start/
               line = error.gets
+              raise process_stderr if line.nil?
+              process_stderr << line
               fatal_time = elapsed_time > timeout
               raise 'webrick server has taken too long to start' if fatal_time
             end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -246,7 +246,11 @@ end
 
 def with_rackup(name, host="127.0.0.1")
   pid, w, r, e = launch_process("rackup", "-s", "webrick", "--host", host, rackup_path(name))
-  until e.gets =~ /HTTPServer#start:/; end
+  process_stderr = ""
+  until (line = e.gets) =~ /HTTPServer#start:/
+    raise process_stderr if line.nil?
+    process_stderr << line
+  end
   yield
 ensure
   cleanup_process(pid)
@@ -271,7 +275,11 @@ def with_unicorn(name, listen='127.0.0.1:9292')
   unless RUBY_PLATFORM == 'java'
     unix_socket = listen.sub('unix://', '') if listen.start_with? 'unix://'
     pid, w, r, e = launch_process("unicorn", "--no-default-middleware","-l", listen, rackup_path(name))
-    until e.gets =~ /worker=0 ready/; end
+    process_stderr = ""
+    until (line = e.gets) =~ /worker=0 ready/
+      raise process_stderr if line.nil?
+      process_stderr << line
+    end
   else
     # need to find suitable server for jruby
   end
@@ -290,7 +298,11 @@ end
 
 def with_server(name)
   pid, w, r, e = launch_process("ruby", server_path("#{name}.rb"))
-  until e.gets =~ /ready/; end
+  process_stderr = ""
+  until (line = e.gets) =~ /ready/
+    raise process_stderr if line.nil?
+    process_stderr << line
+  end
   yield
 ensure
   cleanup_process(pid)


### PR DESCRIPTION
This addresses two issues:

1) When the test server fails for whatever reason, the test suite gets stuck in infinite loop reading stderr output. This can be simply prevented, because when the `gets` reads from closed pipe, it returns `nil`.

2) When the test server fails during startup, there is no way to know why. Therefore the server messages are collected and reported in case the stderr pipe is unexpectedly closed.

Original behavior:

~~~
$ shindont
  
  Excon bad server interaction +++++  
  Excon basics +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon streaming basics #  
  Excon basics (Basic Auth Pass) +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics (Basic Auth Fail) +++  
  Excon basics (ssl) ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics verify_hostname (ssl) ++  
  Excon ssl verify peer (ssl) ++++  
  Excon ssl verify peer (ssl cert store) ++  
  Excon basics (ssl file) (focus) +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics (ssl file paths) (focus) ++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+++++++++++++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+++++++++++++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+  
  Excon basics (ssl string) (focus) ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics (Unix socket) #  
  Excon basics (reusable local port) ++  
  Excon Connection +++++++++++++++++++  
  HTTPStatusError request/response debugging ++++++++++++++  
  Excon response header support +++++++++++++++++++++  
  logging instrumentor +  
  Excon middleware   
  Excon support for middlewares that return canned responses ++  
  Excon redirecting with cookie preserved +  
  Excon Decompress Middleware ++++++++++++++++++  
  Excon Decompress Middleware ++  
  Excon request idempotencey +++++++++++++++  
  Excon instrumentation +++++++++++++++++++++++++++++++  
  Excon stubs +++++++++++++++++++++++++++++++++  
  Excon redirector support +  
  Excon redirector support with redirect loop +  
  Excon redirect support for relative Location headers +  
  Excon redirect support for relative Location headers with dot segments +  
  Excon redirecting post request +  
  Pipelined Requests ++  
  Excon proxy support ++++++++++++++++++++++++++++++++++++++++++++++++++++#  
  Excon query string variants +++++++++++  
  Excon request methods ++  
  Excon request methods +++++++  
~~~

where the process infinitely loops here:

https://github.com/excon/excon/blob/b64de99532b6564b9ff5a5dc90ea6baf8947e81e/tests/test_helper.rb#L247-L251

New behavior:

~~~
$ shindont
  
  Excon bad server interaction +++++  
  Excon basics +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon streaming basics #  
  Excon basics (Basic Auth Pass) +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics (Basic Auth Fail) +++  
  Excon basics (ssl) ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics verify_hostname (ssl) ++  
  Excon ssl verify peer (ssl) ++++  
  Excon ssl verify peer (ssl cert store) ++  
  Excon basics (ssl file) (focus) +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics (ssl file paths) (focus) ++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+++++++++++++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+++++++++++++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
++++++++++:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+:certificate_path is no longer supported and will be deprecated. Please use :client_cert or :client_cert_data
:private_key_path is no longer supported and will be deprecated. Please use :client_key or :client_key_data
+  
  Excon basics (ssl string) (focus) ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
  Excon basics (Unix socket) #  
  Excon basics (reusable local port) ++  
  Excon Connection +++++++++++++++++++  
  HTTPStatusError request/response debugging ++++++++++++++  
  Excon response header support +++++++++++++++++++++  
  logging instrumentor +  
  Excon middleware   
  Excon support for middlewares that return canned responses ++  
  Excon redirecting with cookie preserved +  
  Excon Decompress Middleware ++++++++++++++++++  
  Excon Decompress Middleware ++  
  Excon request idempotencey +++++++++++++++  
  Excon instrumentation +++++++++++++++++++++++++++++++  
  Excon stubs +++++++++++++++++++++++++++++++++  
  Excon redirector support +  
  Excon redirector support with redirect loop +  
  Excon redirect support for relative Location headers +  
  Excon redirect support for relative Location headers with dot segments +  
  Excon redirecting post request +  
  Pipelined Requests ++  
  Excon proxy support ++++++++++++++++++++++++++++++++++++++++++++++++++++#  
  Excon query string variants +++++++++++  
  Excon request methods ++  
  Excon request methods +++++++  
  Request Tests ++++      
      tests/request_tests.rb
        persistent connections
        Request Tests
      /usr/share/gems/gems/eventmachine-1.2.7/lib/eventmachine.rb:531:in `start_tcp_server': no acceptor (port is in use or requires root privileges) (RuntimeError)
	from /usr/share/gems/gems/eventmachine-1.2.7/lib/eventmachine.rb:531:in `start_server'
	from /builddir/build/BUILD/excon-0.85.0/usr/share/gems/gems/excon-0.85.0/tests/servers/good_ipv6.rb:6:in `block in <main>'
	from /usr/share/gems/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run_machine'
	from /usr/share/gems/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run'
	from /builddir/build/BUILD/excon-0.85.0/usr/share/gems/gems/excon-0.85.0/tests/servers/good_ipv6.rb:5:in `<main>'
 (RuntimeError)
        tests/test_helper.rb:303:in `with_server'
        tests/request_tests.rb:6:in `block (3 levels) in <top (required)>'
        tests/request_tests.rb:5:in `each'
        tests/request_tests.rb:5:in `block (2 levels) in <top (required)>'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo.rb:79:in `instance_eval'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo.rb:79:in `tests'
        tests/request_tests.rb:2:in `block in <top (required)>'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo.rb:79:in `instance_eval'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo.rb:79:in `tests'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo.rb:38:in `initialize'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo.rb:13:in `new'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo.rb:13:in `tests'
        tests/request_tests.rb:1:in `<top (required)>'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo/bin.rb:61:in `load'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo/bin.rb:61:in `block (2 levels) in run_in_thread'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo/bin.rb:58:in `each'
        /usr/share/gems/gems/shindo-0.3.10/lib/shindo/bin.rb:58:in `block in run_in_thread'
  
  Excon Response Parsing +++++++++++++++++++++++  
  Excon thread safety ++++  
  read should timeout ++  
  Excon::Utils +++++++++++++++  
  1 errored, 3 pending and 952 succeeded in 13.908285484560059 seconds
~~~