### PR TITLE
[fix] logging behavior for query hashes

### DIFF
--- a/lib/excon/instrumentors/logging_instrumentor.rb
+++ b/lib/excon/instrumentors/logging_instrumentor.rb
@@ -28,7 +28,7 @@ module Excon
           info << "?"
 
           if params[:query].is_a?(Hash)
-            info << params.to_a.map{ |key,value| "#{key}=#{value}" }.join('&')
+            info << params[:query].to_a.map { |key,value| "#{key}=#{value}" }.join('&')
           else
             info << params[:query]
           end

--- a/tests/instrumentors/logging_instrumentor_tests.rb
+++ b/tests/instrumentors/logging_instrumentor_tests.rb
@@ -26,6 +26,33 @@ Shindo.tests('logging instrumentor') do
     ]
   end
 
+  tests("connection logger with query as hash").returns(true) do
+    Excon.stub({:method => :get}, {body: 'body'}, status: 200})
+
+    log_path = "/tmp/excon_#{Time.now.to_i}.txt"
+    logger = Logger.new(log_path)
+    # omit datetime to simplify test matcher
+    logger.formatter = proc do |severity, datetime, progname, msg|
+      "#{msg}\n"
+    end
+
+    connection = Excon.new(
+      'http://127.0.0.1:9292',
+      instrumentor: Excon::LoggingInstrumentor,
+      logger: logger,
+      mock: true
+    )
+    response = connection.request(
+      method: :get,
+      path: '/logger',
+      query: {test: 'test'}
+    )
+    File.readlines(log_path)[1..2] == [
+      "request: http://127.0.0.1/logger?test=test\n",
+      "response: body\n"
+    ]
+  end
+
   Excon.stubs.clear
   env_restore
 end

--- a/tests/instrumentors/logging_instrumentor_tests.rb
+++ b/tests/instrumentors/logging_instrumentor_tests.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'tempfile'
 
 Shindo.tests('logging instrumentor') do
   env_init
@@ -6,7 +7,7 @@ Shindo.tests('logging instrumentor') do
   tests("connection logger").returns(true) do
     Excon.stub({:method => :get}, {body: 'body', status: 200})
 
-    log_path = "/tmp/excon_#{Time.now.to_i}.txt"
+    log_path = Tempfile.create.path
     logger = Logger.new(log_path)
     # omit datetime to simplify test matcher
     logger.formatter = proc do |severity, datetime, progname, msg|
@@ -19,8 +20,10 @@ Shindo.tests('logging instrumentor') do
       logger: logger,
       mock: true
     )
+
     response = connection.request(method: :get, path: '/logger')
-    File.readlines(log_path)[1..2] == [
+
+    File.readlines(log_path) == [
       "request: http://127.0.0.1/logger\n",
       "response: body\n"
     ]
@@ -29,7 +32,7 @@ Shindo.tests('logging instrumentor') do
   tests("connection logger with query as hash").returns(true) do
     Excon.stub({:method => :get}, {body: 'body', status: 200})
 
-    log_path = "/tmp/excon_#{Time.now.to_i}.txt"
+    log_path = Tempfile.create.path
     logger = Logger.new(log_path)
     # omit datetime to simplify test matcher
     logger.formatter = proc do |severity, datetime, progname, msg|
@@ -47,7 +50,7 @@ Shindo.tests('logging instrumentor') do
       path: '/logger',
       query: {test: 'test'}
     )
-    File.readlines(log_path)[1..2] == [
+    File.readlines(log_path) == [
       "request: http://127.0.0.1/logger?test=test\n",
       "response: body\n"
     ]

--- a/tests/instrumentors/logging_instrumentor_tests.rb
+++ b/tests/instrumentors/logging_instrumentor_tests.rb
@@ -27,7 +27,7 @@ Shindo.tests('logging instrumentor') do
   end
 
   tests("connection logger with query as hash").returns(true) do
-    Excon.stub({:method => :get}, {body: 'body'}, status: 200})
+    Excon.stub({:method => :get}, {body: 'body', status: 200})
 
     log_path = "/tmp/excon_#{Time.now.to_i}.txt"
     logger = Logger.new(log_path)


### PR DESCRIPTION
  * we must log only the query when testing for the query as hash
  * see modified behavior inside Excon::Instrumentors::LoggingInstrumentor
  * added very simple test

We found out when our logs got flooded with excon client options information, so I decided to fix it right away for upstream projects.

Let me know when you need changes, other ideas on this PR. Anyways patch is very minor.

Thanks, CR