### PR TITLE
[fix] Read server response during EPIPE

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -190,6 +190,11 @@ module Excon
         case error
         when Excon::Errors::InvalidHeaderKey, Excon::Errors::InvalidHeaderValue, Excon::Errors::StubNotFound, Excon::Errors::Timeout
           raise(error)
+        when Errno::EPIPE
+          # Read whatever remains in the pipe to aid in debugging
+          response = socket.read
+          error = Excon::Error.new(response + error.message)
+          raise_socket_error(error)
         else
           raise_socket_error(error)
         end


### PR DESCRIPTION
When a `request_block` is used to send data, an error on the server side
only gets reported as a `EPIPE`. excon doesn't read anything sent back
from the server, which makes it hard to debug what went wrong.

We now read the server response, if any, and show it in the exception.

For example:

```
/home/stanhu/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/excon-0.85.0/lib/excon/connection.rb:491:in `raise_socket_error': HTTP/1.1 400 Bad Request\r (Excon::Error::Socket)
x-amz-request-id: MEMSPP5B8RB0XNGR\r
x-amz-id-2: ezVTklrChvB5lJDCpCm/IgPg1XkHgCLlJvSrCgQgxNIQQdjIZsMBx5Tfqz79mr1nfPiO99c+4XQ=\r
Content-Type: application/xml\r
Transfer-Encoding: chunked\r
Date: Wed, 15 Sep 2021 04:16:54 GMT\r
Server: AmazonS3\r
Connection: close\r
\r
17c\r
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidArgument</Code><Message>The secret key was invalid for the specified algorithm.</Message><ArgumentName>x-amz-server-side-encryption</ArgumentName><ArgumentValue>null</ArgumentValue><RequestId>MEMSPP5B8RB0XNGR</RequestId><HostId>ezVTklrChvB5lJDCpCm/IgPg1XkHgCLlJvSrCgQgxNIQQdjIZsMBx5Tfqz79mr1nfPiO99c+4XQ=</HostId></Error>\r
0\r
\r
Broken pipe (Excon::Error)
```

Closes #760