### PR TITLE
Stop leaking sensitive header values in error messages

### DIFF
--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -131,7 +131,8 @@ module Excon
         end
         [values].flatten.each do |value|
           if value.to_s.match(/[\r\n]/)
-            raise Excon::Errors::InvalidHeaderValue.new(value.to_s.inspect + ' contains forbidden "\r" or "\n"')
+            # Don't include the potentially sensitive header value (i.e. authorization token) in the message
+            raise Excon::Errors::InvalidHeaderValue.new(key.to_s + ' header value contains forbidden "\r" or "\n"')
           end
           headers_str << key.to_s << ': ' << value.to_s << CR_NL
         end


### PR DESCRIPTION
The protection against invalid header values should not leak their
content in the error message. Exceptions are commonly logged, sent to
third-party error monitoring systems, or published in internal
communication/messenger systems. A range of HTTP headers, like
`Authorization`, `Api-Key`, or similar, contain sensitive information
which should not be sent to such public destinations.

---

Thank you for excon, a great library!

The protection against invalid header values is helpful, but we accidentally leaked an API token today (exception -> Bugsnag -> Slack) which was passed from an `ENV["API_TOKEN"]` environment variable.
