### PR TITLE
Support ActiveSupport v7

### DIFF
--- a/tests/middlewares/instrumentation_tests.rb
+++ b/tests/middlewares/instrumentation_tests.rb
@@ -1,4 +1,4 @@
-require 'active_support/notifications'
+require 'active_support'
 require 'securerandom'
 
 class SimpleInstrumentor


### PR DESCRIPTION
https://github.com/excon/excon/runs/4781841441 was failing:

```
 Excon instrumentation
    basic notification - returns ["excon.request", "excon.response"]
    uninitialized constant ActiveSupport::IsolatedExecutionState (NameError)
      /home/runner/work/excon/excon/vendor/bundle/ruby/3.0.0/gems/activesupport-7.0.1/lib/active_support/notifications.rb:268:in `registry'
      /home/runner/work/excon/excon/vendor/bundle/ruby/3.0.0/gems/activesupport-7.0.1/lib/active_support/notifications.rb:263:in `instrumenter'
      /home/runner/work/excon/excon/vendor/bundle/ruby/3.0.0/gems/activesupport-7.0.1/lib/active_support/notifications.rb:206:in `instrument'
```

As https://github.com/rails/rails/pull/43852 explains, we can just
`require active_support` and this will auto-load the correct constants.