### PR TITLE
Always set OpenSSL default paths

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -54,11 +54,13 @@ module Excon
           ssl_context.cert_store = cert_store
         end
 
-        # no defaults, fallback to bundled
-        unless ca_file || ca_path || cert_store
+        if cert_store.nil?
           ssl_context.cert_store = OpenSSL::X509::Store.new
           ssl_context.cert_store.set_default_paths
+        end
 
+        # no defaults, fallback to bundled
+        unless ca_file || ca_path || cert_store
           # workaround issue #257 (JRUBY-6970)
           ca_file = DEFAULT_CA_FILE
           ca_file = ca_file.gsub(/^jar:/, '') if ca_file =~ /^jar:file:\//


### PR DESCRIPTION
Previously if you set `SSL_CERT_FILE` to a directory with no certs,
this script would fail:

```ruby
require 'openssl'
require 'excon'

ENV['SSL_CERT_DIR'] = '/path/to/no/ssl/certs/'

excon = Excon.new('https://www.google.com')
excon.get
```

However, the same script with `Net::HTTP` works fine:

```ruby
require 'openssl'
require 'net/http'

ENV['SSL_CERT_DIR'] = '/path/to/no/ssl/certs/'

Net::HTTP.get(URI('https://www.google.com'))
```

To match the behavior of Net::HTTP, always call
`OpenSSL::X509::Store#set_default_paths` unless there is a store
specified.