### PR TITLE
Proposal: Omit default port (80 and 443) by default

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -154,7 +154,7 @@ module Excon
     ],
     :mock                 => false,
     :nonblock             => true,
-    :omit_default_port    => false,
+    :omit_default_port    => true,
     :persistent           => false,
     :read_timeout         => 60,
     :retry_errors         => DEFAULT_RETRY_ERRORS,


### PR DESCRIPTION
I recently dealt with a server that misbehaves when the `:443` was added to the `Host` header, which required me a lot of investigation to understand what was happening. Setting `omit_default_port` to `true` was the solution.

Omitting when default is the most common behavior. Browsers omit them, `curl` omit as well, etc.

The [RFC](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23) does not say it's prohibited to add the port, but say it's not required, suggesting that omitting is preferred.