### PR TITLE
Use StandardInstrumentor if any debug mode is enabled

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -79,12 +79,11 @@ module Excon
 
       setup_proxy
 
-      if ENV.has_key?('EXCON_STANDARD_INSTRUMENTOR')
-        @data[:instrumentor] = Excon::StandardInstrumentor
-      end
-
       if @data[:debug] || ENV.has_key?('EXCON_DEBUG')
         @data[:debug_request] = @data[:debug_response] = true
+      end
+
+      if @data[:debug_request] || @data[:debug_response] || ENV.has_key?('EXCON_STANDARD_INSTRUMENTOR')
         @data[:instrumentor] = Excon::StandardInstrumentor
       end
 


### PR DESCRIPTION
So far the StandardInstrumentor was only set for the :debug helper
setting, but not when the specific :debug_request or :debug_response
settings were used.

---

@geemus Well, I feel silly for opening such a simple PR :sweat_smile:. I don't immediately see how to test this as I'm unfamiliar with the code base and internals, so this is literally just how I understood your suggestion.

Besides the tests, my biggest question is around the behavior when the user has already set the `:instrumentor` option? Does it need some dispatch instrumentor which can call multiple instrumentors at the same time? I haven't seen anything like that immediately.