### PR TITLE
Use `ssl_verify_peer_host` for SNI if configured

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -133,7 +133,7 @@ module Excon
 
       # Server Name Indication (SNI) RFC 3546
       if @socket.respond_to?(:hostname=)
-        @socket.hostname = @data[:host]
+        @socket.hostname = @data[:ssl_verify_peer_host] || @data[:host]
       end
 
       begin

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -185,6 +185,21 @@ Shindo.tests('Excon ssl verify peer (ssl)') do
       response.status
     end
   end
+
+  with_rackup('ssl_sni_verify_host.ru') do
+    connection = nil
+    test do
+      ssl_ca_file = File.join(File.dirname(__FILE__), 'data', 'excon.cert.crt')
+      connection = Excon.new('https://127.0.0.1:9443', :ssl_verify_peer => true, :ssl_ca_file => ssl_ca_file, :ssl_verify_peer_host => 'excon' )
+      true
+    end
+
+    tests('response.status').returns(200) do
+      response = connection.request(:method => :get, :path => '/content-length/100')
+
+      response.status
+    end
+  end
 end
 
 Shindo.tests('Excon ssl verify peer (ssl cert store)') do

--- a/tests/rackups/ssl_sni_verify_host.ru
+++ b/tests/rackups/ssl_sni_verify_host.ru
@@ -1,0 +1,27 @@
+require 'openssl'
+require 'webrick'
+require 'webrick/https'
+
+require File.join(File.dirname(__FILE__), 'basic')
+key_file = File.join(File.dirname(__FILE__), '..', 'data', 'excon.cert.key')
+cert_file = File.join(File.dirname(__FILE__), '..', 'data', 'excon.cert.crt')
+
+# Responds with generated certificate by default
+# Responds with `excon.cert` for when SNI is `excon`
+Rack::Handler::WEBrick.run(Basic,
+  :Port             => 9443,
+  :SSLEnable        => true,
+  :SSLCertName => [%w{CN example.com}],
+) do |server|
+  excon_vhost = ::WEBrick::HTTPServer.new(
+    :SSLEnable        => true,
+    :Port             => 9443,
+    :ServerName       => "excon",
+    :SSLPrivateKey    => OpenSSL::PKey::RSA.new(File.open(key_file).read),
+    :SSLCertificate   => OpenSSL::X509::Certificate.new(File.open(cert_file).read),
+    :SSLCACertificateFile => cert_file,
+    :SSLVerifyClient  => OpenSSL::SSL::VERIFY_NONE,
+    :DoNotListen         => true
+  )
+  server.virtual_host excon_vhost
+end


### PR DESCRIPTION
When set, `ssl_verify_peer_host` is used to verify the certificate of the SSL connection after it's opened.

https://github.com/excon/excon/blob/226924e59db71a1c8ce54a682cb343c55be44219/lib/excon/ssl_socket.rb#L155-L158

To ensure the server responds with the appropriate certificate, we need to use this same `ssl_verify_peer_host` value for SNI as well.