### PR TITLE
Move read_buffer guards in Socket

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -185,7 +185,9 @@ module Excon
         end
       rescue OpenSSL::SSL::SSLError => error
         if error.message == 'read would block'
-          select_with_timeout(@socket, :read) && retry
+          if @read_buffer.empty?
+            select_with_timeout(@socket, :read) && retry
+          end
         else
           raise(error)
         end

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -221,9 +221,7 @@ module Excon
         raise(error)
       end
     rescue *READ_RETRY_EXCEPTION_CLASSES
-      if @read_buffer.empty?
-        select_with_timeout(@socket, :read) && retry
-      end
+      select_with_timeout(@socket, :read) && retry
     rescue EOFError
       @eof = true
     end

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -23,69 +23,6 @@ Shindo.tests('Excon basics') do
   end
 end
 
-# expected values: the response, in pieces, and a timeout after each piece
-STREAMING_PIECES = %w{Hello streamy world}
-STREAMING_TIMEOUT = 0.1
-
-def streaming_tests
-  # expect the full response as a string
-  # and expect it to take a (timeout * pieces) seconds
-  tests('simple blocking request on streaming endpoint').returns([STREAMING_PIECES.join(''),'response time ok']) do
-    start = Time.now
-    ret = Excon.get('http://127.0.0.1:9292/streamed/simple').body
-
-    if Time.now - start <= STREAMING_TIMEOUT*3
-      [ret, 'streaming response came too quickly']
-    else
-      [ret, 'response time ok']
-    end
-  end
-
-  # expect the full response as a string and expect it to
-  # take a (timeout * pieces) seconds (with fixed Content-Length header)
-  tests('simple blocking request on streaming endpoint with fixed length').returns([STREAMING_PIECES.join(''),'response time ok']) do
-    start = Time.now
-    ret = Excon.get('http://127.0.0.1:9292/streamed/fixed_length').body
-
-    if Time.now - start <= STREAMING_TIMEOUT*3
-      [ret, 'streaming response came too quickly']
-    else
-      [ret, 'response time ok']
-    end
-  end
-
-  # expect each response piece to arrive to the body right away
-  # and wait for timeout until next one arrives
-  def timed_streaming_test(endpoint, timeout)
-    ret = []
-    timing = 'response times ok'
-    start = Time.now
-    Excon.get(endpoint, :response_block => lambda do |c,r,t|
-      # add the response
-      ret.push(c)
-      # check if the timing is ok
-      # each response arrives after timeout and before timeout + 1
-      cur_time = Time.now - start
-      if cur_time < ret.length * timeout or cur_time > (ret.length+1) * timeout
-        timing = 'response time not ok!'
-      end
-    end)
-    # validate the final timing
-    if Time.now - start <= timeout*3
-      timing = 'final timing was not ok!'
-    end
-    [ret, timing]
-  end
-
-  tests('simple request with response_block on streaming endpoint').returns([STREAMING_PIECES,'response times ok']) do
-    timed_streaming_test('http://127.0.0.1:9292/streamed/simple', STREAMING_TIMEOUT)
-  end
-
-  tests('simple request with response_block on streaming endpoint with fixed length').returns([STREAMING_PIECES,'response times ok']) do
-    timed_streaming_test('http://127.0.0.1:9292/streamed/fixed_length', STREAMING_TIMEOUT)
-  end
-end
-
 Shindo.tests('Excon streaming basics') do
   pending if RUBY_PLATFORM == 'java' # need to find suitable server for jruby
   with_unicorn('streaming.ru') do

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -23,70 +23,73 @@ Shindo.tests('Excon basics') do
   end
 end
 
+# expected values: the response, in pieces, and a timeout after each piece
+STREAMING_PIECES = %w{Hello streamy world}
+STREAMING_TIMEOUT = 0.1
+
+def streaming_tests
+  # expect the full response as a string
+  # and expect it to take a (timeout * pieces) seconds
+  tests('simple blocking request on streaming endpoint').returns([STREAMING_PIECES.join(''),'response time ok']) do
+    start = Time.now
+    ret = Excon.get('http://127.0.0.1:9292/streamed/simple').body
+
+    if Time.now - start <= STREAMING_TIMEOUT*3
+      [ret, 'streaming response came too quickly']
+    else
+      [ret, 'response time ok']
+    end
+  end
+
+  # expect the full response as a string and expect it to
+  # take a (timeout * pieces) seconds (with fixed Content-Length header)
+  tests('simple blocking request on streaming endpoint with fixed length').returns([STREAMING_PIECES.join(''),'response time ok']) do
+    start = Time.now
+    ret = Excon.get('http://127.0.0.1:9292/streamed/fixed_length').body
+
+    if Time.now - start <= STREAMING_TIMEOUT*3
+      [ret, 'streaming response came too quickly']
+    else
+      [ret, 'response time ok']
+    end
+  end
+
+  # expect each response piece to arrive to the body right away
+  # and wait for timeout until next one arrives
+  def timed_streaming_test(endpoint, timeout)
+    ret = []
+    timing = 'response times ok'
+    start = Time.now
+    Excon.get(endpoint, :response_block => lambda do |c,r,t|
+      # add the response
+      ret.push(c)
+      # check if the timing is ok
+      # each response arrives after timeout and before timeout + 1
+      cur_time = Time.now - start
+      if cur_time < ret.length * timeout or cur_time > (ret.length+1) * timeout
+        timing = 'response time not ok!'
+      end
+    end)
+    # validate the final timing
+    if Time.now - start <= timeout*3
+      timing = 'final timing was not ok!'
+    end
+    [ret, timing]
+  end
+
+  tests('simple request with response_block on streaming endpoint').returns([STREAMING_PIECES,'response times ok']) do
+    timed_streaming_test('http://127.0.0.1:9292/streamed/simple', STREAMING_TIMEOUT)
+  end
+
+  tests('simple request with response_block on streaming endpoint with fixed length').returns([STREAMING_PIECES,'response times ok']) do
+    timed_streaming_test('http://127.0.0.1:9292/streamed/fixed_length', STREAMING_TIMEOUT)
+  end
+end
+
 Shindo.tests('Excon streaming basics') do
   pending if RUBY_PLATFORM == 'java' # need to find suitable server for jruby
   with_unicorn('streaming.ru') do
-    # expected values: the response, in pieces, and a timeout after each piece
-    res = %w{Hello streamy world}
-    timeout = 0.1
-
-    # expect the full response as a string
-    # and expect it to take a (timeout * pieces) seconds
-    tests('simple blocking request on streaming endpoint').returns([res.join(''),'response time ok']) do
-      start = Time.now
-      ret = Excon.get('http://127.0.0.1:9292/streamed/simple').body
-
-      if Time.now - start <= timeout*3
-        [ret, 'streaming response came too quickly']
-      else
-        [ret, 'response time ok']
-      end
-    end
-
-    # expect the full response as a string and expect it to
-    # take a (timeout * pieces) seconds (with fixed Content-Length header)
-    tests('simple blocking request on streaming endpoint with fixed length').returns([res.join(''),'response time ok']) do
-      start = Time.now
-      ret = Excon.get('http://127.0.0.1:9292/streamed/fixed_length').body
-
-      if Time.now - start <= timeout*3
-        [ret, 'streaming response came too quickly']
-      else
-        [ret, 'response time ok']
-      end
-    end
-
-    # expect each response piece to arrive to the body right away
-    # and wait for timeout until next one arrives
-    def timed_streaming_test(endpoint, timeout)
-      ret = []
-      timing = 'response times ok'
-      start = Time.now
-      Excon.get(endpoint, :response_block => lambda do |c,r,t|
-        # add the response
-        ret.push(c)
-        # check if the timing is ok
-        # each response arrives after timeout and before timeout + 1
-        cur_time = Time.now - start
-        if cur_time < ret.length * timeout or cur_time > (ret.length+1) * timeout
-          timing = 'response time not ok!'
-        end
-      end)
-      # validate the final timing
-      if Time.now - start <= timeout*3
-        timing = 'final timing was not ok!'
-      end
-      [ret, timing]
-    end
-
-    tests('simple request with response_block on streaming endpoint').returns([res,'response times ok']) do
-      timed_streaming_test('http://127.0.0.1:9292/streamed/simple', timeout)
-    end
-
-    tests('simple request with response_block on streaming endpoint with fixed length').returns([res,'response times ok']) do
-      timed_streaming_test('http://127.0.0.1:9292/streamed/fixed_length', timeout)
-    end
-
+    streaming_tests
   end
 end
 

--- a/tests/basic_tests.rb
+++ b/tests/basic_tests.rb
@@ -24,9 +24,16 @@ Shindo.tests('Excon basics') do
 end
 
 Shindo.tests('Excon streaming basics') do
-  pending if RUBY_PLATFORM == 'java' # need to find suitable server for jruby
-  with_unicorn('streaming.ru') do
-    streaming_tests
+  tests('http') do
+    pending if RUBY_PLATFORM == 'java' # need to find suitable server for jruby
+    with_unicorn('streaming.ru') do
+      streaming_tests('http')
+    end
+  end
+  tests('https') do
+    with_ssl_streaming(9292, STREAMING_PIECES, STREAMING_TIMEOUT) do
+      streaming_tests('https')
+    end
   end
 end
 

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -213,6 +213,70 @@ def basic_tests(url = 'http://127.0.0.1:9292', options = {})
 end
 
 
+# expected values: the response, in pieces, and a timeout after each piece
+STREAMING_PIECES = %w{Hello streamy world}
+STREAMING_TIMEOUT = 0.1
+
+def streaming_tests
+  # expect the full response as a string
+  # and expect it to take a (timeout * pieces) seconds
+  tests('simple blocking request on streaming endpoint').returns([STREAMING_PIECES.join(''),'response time ok']) do
+    start = Time.now
+    ret = Excon.get('http://127.0.0.1:9292/streamed/simple').body
+
+    if Time.now - start <= STREAMING_TIMEOUT*3
+      [ret, 'streaming response came too quickly']
+    else
+      [ret, 'response time ok']
+    end
+  end
+
+  # expect the full response as a string and expect it to
+  # take a (timeout * pieces) seconds (with fixed Content-Length header)
+  tests('simple blocking request on streaming endpoint with fixed length').returns([STREAMING_PIECES.join(''),'response time ok']) do
+    start = Time.now
+    ret = Excon.get('http://127.0.0.1:9292/streamed/fixed_length').body
+
+    if Time.now - start <= STREAMING_TIMEOUT*3
+      [ret, 'streaming response came too quickly']
+    else
+      [ret, 'response time ok']
+    end
+  end
+
+  # expect each response piece to arrive to the body right away
+  # and wait for timeout until next one arrives
+  def timed_streaming_test(endpoint, timeout)
+    ret = []
+    timing = 'response times ok'
+    start = Time.now
+    Excon.get(endpoint, :response_block => lambda do |c,r,t|
+      # add the response
+      ret.push(c)
+      # check if the timing is ok
+      # each response arrives after timeout and before timeout + 1
+      cur_time = Time.now - start
+      if cur_time < ret.length * timeout or cur_time > (ret.length+1) * timeout
+        timing = 'response time not ok!'
+      end
+    end)
+    # validate the final timing
+    if Time.now - start <= timeout*3
+      timing = 'final timing was not ok!'
+    end
+    [ret, timing]
+  end
+
+  tests('simple request with response_block on streaming endpoint').returns([STREAMING_PIECES,'response times ok']) do
+    timed_streaming_test('http://127.0.0.1:9292/streamed/simple', STREAMING_TIMEOUT)
+  end
+
+  tests('simple request with response_block on streaming endpoint with fixed length').returns([STREAMING_PIECES,'response times ok']) do
+    timed_streaming_test('http://127.0.0.1:9292/streamed/fixed_length', STREAMING_TIMEOUT)
+  end
+end
+
+
 PROXY_ENV_VARIABLES = %w{http_proxy https_proxy no_proxy} # All lower-case
 
 def env_init(env={})


### PR DESCRIPTION
Socket#read_nonblock currently has a [guard around selecting on the socket](https://github.com/excon/excon/blob/17ed91945ea07d781a984a31411d6adf814bf53e/lib/excon/socket.rb#L193-L196) in the HTTP case. This makes sure that if we have any data, we don't block waiting for more, but just return it right away.

However, the [HTTPS case does not include such a guard](https://github.com/excon/excon/blob/17ed91945ea07d781a984a31411d6adf814bf53e/lib/excon/socket.rb#L188). This PR proves that this is mistaken, but running streaming tests in SSL mode, and showing that they fail without the guard, but pass once it's added.

We also remove the [superfluous guard in read_block](https://github.com/excon/excon/blob/17ed91945ea07d781a984a31411d6adf814bf53e/lib/excon/socket.rb#L222-L224), since it doesn't make sense. In blocking mode, `@read_buffer` is unused and will always be empty—checking if it's empty is harmless, but complicates the code and achieves nothing.

Best reviewed commit-by-commit:
* Commits 1-2 prepare for running streaming tests in multiple modes (HTTP/HTTPS), by factoring out these tests into a method, and moving it to test_helper.rb
* Commit 3 adds a small bespoke SSL streaming server, and runs the streaming tests against it
    * I couldn't find any simpler way to run an SSL streaming server, other than writing it myself. WEBrick doesn't like streaming, Unicorn doesn't do SSL without a proxy, Thin has a weird streaming model that I don't understand. Ideas welcome!
    * Here's the [test output we get as of this commit](https://gist.github.com/vasi-stripe/dbcb220751886de02f9a58c4fafda52c). Note the SSL streaming tests fail, because once we've read "Hello" we get a "would block" error and wait for more data—instead of returning what we have right away, as a non-block socket should.
* Commit 4 fixes the above test failures, by adding the guard. Now if we have some data, we return it instead of waiting.
* Commit 5 removes the superfluous guard in read_block, since `@read_buffer` will always be empty in blocking mode