### PR TITLE
Add scheme, query and method attributes to the response

### DIFF
--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -32,6 +32,9 @@ module Excon
     def path
       @data[:path]
     end
+    def query
+      @data[:query]
+    end
     def port
       @data[:port]
     end
@@ -78,6 +81,7 @@ module Excon
         :scheme          => datum[:scheme],
         :headers       => Excon::Headers.new,
         :path          => datum[:path],
+        :query          => datum[:query],
         :port          => datum[:port],
         :status        => status,
         :status_line   => line,

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -29,6 +29,9 @@ module Excon
     def local_port
       @data[:local_port]
     end
+    def http_method # can't be named "method"
+      @data[:method]
+    end
     def path
       @data[:path]
     end
@@ -79,6 +82,7 @@ module Excon
         :cookies       => [],
         :host          => datum[:host],
         :scheme          => datum[:scheme],
+        :method          => datum[:method],
         :headers       => Excon::Headers.new,
         :path          => datum[:path],
         :query          => datum[:query],

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -20,6 +20,9 @@ module Excon
     def host
       @data[:host]
     end
+    def scheme
+      @data[:scheme]
+    end
     def local_address
       @data[:local_address]
     end
@@ -72,6 +75,7 @@ module Excon
         :body          => String.new,
         :cookies       => [],
         :host          => datum[:host],
+        :scheme          => datum[:scheme],
         :headers       => Excon::Headers.new,
         :path          => datum[:path],
         :port          => datum[:port],


### PR DESCRIPTION
Adds `scheme`, `query`, and `method` attribute to the response. This makes it easier for logs and when writing URIs for responses using `Excon::Utils.request_uri(response)`

Fixes #795 