### PR TITLE
Convert empty host string from 'uri' to `nil`

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -126,7 +126,10 @@ module Excon
         raise ArgumentError.new("Invalid URI: #{uri}")
       end
       params = {
-        :host       => uri.host,
+        # 'uri' >= v0.12.0 returns an empty string instead of nil for no host.
+        # Convert it back here so the rest of the code doesn't have to care about
+        # handling different versions of 'uri'.
+        :host       => (uri.host && !uri.host.empty?) ? uri.host : nil,
         :hostname   => uri.hostname,
         :path       => uri.path,
         :port       => uri.port,
@@ -152,7 +155,10 @@ module Excon
       if (url = request_params.delete(:url))
         uri = URI.parse(url)
         request_params = {
-          :host              => uri.host,
+          # 'uri' >= v0.12.0 returns an empty string instead of nil for no host.
+          # Convert it back here so the rest of the code doesn't have to care about
+          # handling different versions of 'uri'.
+          :host              => (uri.host && !uri.host.empty?) ? uri.host : nil,
           :path              => uri.path,
           :port              => uri.port,
           :query             => uri.query,

--- a/spec/requests/unix_socket_spec.rb
+++ b/spec/requests/unix_socket_spec.rb
@@ -3,6 +3,17 @@ require "spec_helper"
 describe Excon::Connection do
   include_context('stubs')
   context "when speaking to a UNIX socket" do
+    # Excon.new does some extra URL parsing, which makes
+    # it a bit special compared to bare `Excon::Connection.new`.
+    context "via Excon.new" do
+      # Version 0.12.0 of the 'uri' gem changed
+      # from returning `nil` for no host to returning
+      # an empty string.
+      it "accepts the unix:/ URL" do
+        Excon.new('unix:///', {socket: '/tmp/foo'})
+      end
+    end
+
     context "Host header handling" do
       before do
         Excon.stub do |req|


### PR DESCRIPTION
'uri' gem >= v0.12.0 (which the version of the default gem in Ruby 3.2) returns an empty string instead of nil for no host. Convert it back to `nil` as soon as possible so the rest of the code doesn't have to care about handling different versions of 'uri'.

Fixes https://github.com/excon/excon/issues/805.