### PR TITLE
Treat 'host' in URI as present only if non-empty

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -89,7 +89,9 @@ module Excon
       end
 
       if @data[:scheme] == UNIX
-        if @data[:host]
+        # 'uri' >= v0.12.0 returns an empty string instead of nil for no host.
+        # So treat the parameter as present if and only if it is both non-nill and non-empty.
+        if @data[:host] && !@data[:host].empty?
           raise ArgumentError, "The `:host` parameter should not be set for `unix://` connections.\n" +
                                "When supplying a `unix://` URI, it should start with `unix:/` or `unix:///`."
         elsif !@data[:socket]

--- a/spec/requests/unix_socket_spec.rb
+++ b/spec/requests/unix_socket_spec.rb
@@ -3,6 +3,17 @@ require "spec_helper"
 describe Excon::Connection do
   include_context('stubs')
   context "when speaking to a UNIX socket" do
+    # `Excon.new`` does some extra URL parsing, which makes
+    # it a bit special compared to bare `Excon::Connection.new`.
+    context "via Excon.new" do
+      # Version 0.12.0 of the 'uri' gem changed
+      # from returning `nil` for no host to returning
+      # an empty string.
+      it "accepts the unix:/ URL" do
+        Excon.new('unix:///', {socket: '/tmp/foo'})
+      end
+    end
+
     context "Host header handling" do
       before do
         Excon.stub do |req|


### PR DESCRIPTION
'uri' >= v0.12.0 returns an empty string instead of nil for no host. So treat the parameter as present if and only if it is both non-nill and non-empty.

This is an alternative to https://github.com/excon/excon/pull/806.