### PR TITLE
Convert proxy host value to nil if needed.

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -579,6 +579,8 @@ module Excon
           raise ArgumentError, "The `:ssl_proxy_headers` parameter should only be used with HTTPS requests."
         end
         if @data[:proxy][:scheme] == UNIX
+          # URI.parse might return empty string for security reasons.
+          @data[:proxy][:host] = nil if @data[:proxy][:host] == ""
           if @data[:proxy][:host]
             raise ArgumentError, "The `:host` parameter should not be set for `unix://` proxies.\n" +
                                  "When supplying a `unix://` URI, it should start with `unix:/` or `unix:///`."


### PR DESCRIPTION
`URI.parse` used to return `nil` for `host`, when parsing `unix:` URI. However, it returens empty string since Ruby 3.2 / URI v0.12.0 for security reasons:

https://hackerone.com/reports/156615
https://github.com/ruby/uri/commit/81263c9e94bd67ca01deee238842a88c2c8885f3