### PR TITLE
Automatic Fork Safety

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -62,6 +62,7 @@ module Excon
     # @option params [Class] :instrumentor Responds to #instrument as in ActiveSupport::Notifications
     # @option params [String] :instrumentor_name Name prefix for #instrument events.  Defaults to 'excon'
     def initialize(params = {})
+      @pid = Process.pid
       @data = Excon.defaults.dup
       # merge does not deep-dup, so make sure headers is not the original
       @data[:headers] = @data[:headers].dup
@@ -479,6 +480,11 @@ module Excon
     def sockets
       @_excon_sockets ||= {}
       @_excon_sockets.compare_by_identity
+
+      if @pid != Process.pid
+        @_excon_sockets.clear # GC will take care of closing sockets
+        @pid = Process.pid
+      end
 
       if @data[:thread_safe_sockets]
         # In a multi-threaded world, if the same connection is used by multiple


### PR DESCRIPTION
Forking servers are a popular deployment method in Ruby. One big footgun is that uppon fork, all file descriptors are inherited, so if you create some FDs before fork and hold on them you may end up with the same connection being used across many process creating havoc.

As such it's a good idea for libraries that do keep persistent connections do check the PID before re-using them.

The alternative is for libraries to provide some kind of callback that the application has to call before fork, but that's easilly missed by users and the PID check is very cheap.