### PR TITLE
Add JRuby into test matrix.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head', 'jruby']
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   test:
-    continue-on-error: ${{ matrix.ruby-version == 'head' }}
+    continue-on-error: ${{ contains(fromJSON('["head", "jruby"]'), matrix.ruby-version) }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
It was previously dropped by 27d23c4 for too many failures. But since there are JRuby code paths, they should be either tested or dropped. Closing eyes does not help probably.

Please note that I am not JRuby user myself, but I care about code readability and clarity.