### PR TITLE
Add a request timeout to Excon for non-blocking sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ connection.request(:read_timeout => 360)
 # set longer write_timeout (default is 60 seconds)
 connection.request(:write_timeout => 360)
 
+# set a request timeout in seconds (default is no timeout)
+connection.request(:timeout => 5)
+
 # Enable the socket option TCP_NODELAY on the underlying socket.
 #
 # This can improve response time when sending frequent short

--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ connection.request(:read_timeout => 360)
 # set longer write_timeout (default is 60 seconds)
 connection.request(:write_timeout => 360)
 
-# set a request timeout in seconds (default is no timeout)
-connection.request(:timeout => 5)
+# set a request timeout in seconds (default is no timeout).
+# the timeout may be an integer or a float to support sub-second granularity (e.g., 1, 60, 0.005 and 3.5).
+connection.request(:timeout => 0.1) # timeout if the entire request takes longer than 100 milliseconds
 
 # Enable the socket option TCP_NODELAY on the underlying socket.
 #

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -232,7 +232,8 @@ module Excon
       datum = @data.merge(params)
 
       # Set the deadline for the current request in order to determine when we have run out of time.
-      if datum.include?(:timeout)
+      # Only set when a request timeout has been defined.
+      if datum[:timeout]
         datum[:deadline] = Process.clock_gettime(Process::CLOCK_MONOTONIC) + datum[:timeout]
       end
 

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -232,7 +232,9 @@ module Excon
       datum = @data.merge(params)
 
       # Set the deadline for the current request in order to determine when we have run out of time.
-      datum[:deadline] = Process.clock_gettime(Process::CLOCK_MONOTONIC) + datum[:timeout]
+      if datum.include?(:timeout)
+        datum[:deadline] = Process.clock_gettime(Process::CLOCK_MONOTONIC) + datum[:timeout]
+      end
 
       datum[:headers] = @data[:headers].merge(datum[:headers] || {})
 

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -230,6 +230,10 @@ module Excon
     def request(params={}, &block)
       # @data has defaults, merge in new params to override
       datum = @data.merge(params)
+
+      # Set the deadline for the current request in order to determine when we have run out of time.
+      datum[:deadline] = Process.clock_gettime(Process::CLOCK_MONOTONIC) + datum[:timeout]
+
       datum[:headers] = @data[:headers].merge(datum[:headers] || {})
 
       validate_params(:request, params, datum[:middlewares])

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -172,7 +172,7 @@ module Excon
     :stubs               => :global,
     :tcp_nodelay         => false,
     :thread_safe_sockets => true,
-    :timeout             => 360,
+    :timeout             => nil,
     :uri_parser          => URI,
     :versions            => VERSIONS,
     :write_timeout       => 60

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -62,6 +62,7 @@ module Excon
     :resolv_resolver,
     :response_block,
     :stubs,
+    :timeout,
     :user,
     :versions,
     :write_timeout
@@ -171,6 +172,7 @@ module Excon
     :stubs               => :global,
     :tcp_nodelay         => false,
     :thread_safe_sockets => true,
+    :timeout             => 360,
     :uri_parser          => URI,
     :versions            => VERSIONS,
     :write_timeout       => 60

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -315,7 +315,7 @@ module Excon
       timeout = @data[OPERATION_TO_TIMEOUT[type]]
 
       if @data.include?(:deadline)
-        remaining = check_deadline!
+        remaining = request_time_remaining
 
         if remaining < timeout
           timeout_kind = :request
@@ -345,9 +345,9 @@ module Excon
       end
     end
 
-    # Checks whether we have exceeded the request deadline.
-    # Returns the remaining time in seconds until we reach the deadline.
-    def check_deadline!
+    # Returns the remaining time in seconds until we reach the deadline for the request timeout.
+    # Raises an exception if we have exceeded the request timeout's deadline.
+    def request_time_remaining
       now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       deadline = @data[:deadline]
       

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -342,7 +342,7 @@ module Excon
       now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       deadline = @data[:deadline]
       
-      raise raise(Excon::Errors::Timeout.new("request timeout reached")) if now >= deadline
+      raise raise(Excon::Errors::Timeout.new('request timeout reached')) if now >= deadline
 
       remaining  = deadline - now
 

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -9,8 +9,6 @@ module Excon
 
     attr_accessor :data
 
-    REQUEST_TIMEOUT_KIND = "request"
-
     # read/write drawn from https://github.com/ruby-amqp/bunny/commit/75d9dd79551b31a5dd3d1254c537bad471f108cf
     CONNECT_RETRY_EXCEPTION_CLASSES = if defined?(IO::EINPROGRESSWaitWritable) # Ruby >= 2.1
       [Errno::EINPROGRESS, IO::EINPROGRESSWaitWritable]
@@ -346,7 +344,7 @@ module Excon
 
       remaining  = deadline - now
 
-      remaining < timeout ? [REQUEST_TIMEOUT_KIND, remaining] : [type, timeout]
+      remaining < timeout ? [:request, remaining] : [type, timeout]
     end
   end
 end

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -314,12 +314,15 @@ module Excon
       timeout_kind = type
       timeout = @data[OPERATION_TO_TIMEOUT[type]]
 
+      # Check whether the request has a timeout configured.
       if @data.include?(:deadline)
-        remaining = request_time_remaining
+        request_timeout = request_time_remaining
 
-        if remaining < timeout
+        # If the time remaining until the request times out is less than the timeout for the type of select,
+        # use the time remaining as the timeout instead.
+        if request_timeout < timeout
           timeout_kind = :request
-          timeout = remaining
+          timeout = request_timeout
         end
       end
 

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -296,7 +296,7 @@ module Excon
     end
 
     def write_block(data)
-              @socket.write(data)
+      @socket.write(data)
     rescue OpenSSL::SSL::SSLError, *WRITE_RETRY_EXCEPTION_CLASSES => error
       if error.is_a?(OpenSSL::SSL::SSLError) && error.message != 'write would block'
         raise error

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -247,7 +247,7 @@ module Excon
     end
 
     def read_block(max_length)
-              @socket.read(max_length)
+      @socket.read(max_length)
     rescue OpenSSL::SSL::SSLError => error
       if error.message == 'read would block'
         select_with_timeout(@socket, :read) && retry

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -337,6 +337,8 @@ module Excon
     # Checks whether we have exceeded the request deadline.
     # Returns the remaining time in seconds as Numeric.
     def check_deadline!(type, timeout)
+      return [type, timeout] unless @data.include?(:deadline)
+
       now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       deadline = @data[:deadline]
       

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -315,8 +315,8 @@ module Excon
       timeout = @data[OPERATION_TO_TIMEOUT[type]]
 
       if @data.include?(:deadline)
-        remaining = check_deadline!(timeout_kind, timeout)
-        
+        remaining = check_deadline!
+
         if remaining < timeout
           timeout_kind = :request
           timeout = remaining
@@ -346,8 +346,8 @@ module Excon
     end
 
     # Checks whether we have exceeded the request deadline.
-    # Returns the type of timeout and timeout duration.
-    def check_deadline!(type, timeout)
+    # Returns the remaining time in seconds until we reach the deadline.
+    def check_deadline!
       now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       deadline = @data[:deadline]
       

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -315,7 +315,12 @@ module Excon
       timeout = @data[OPERATION_TO_TIMEOUT[type]]
 
       if @data.include?(:deadline)
-        timeout_kind, timeout = check_deadline!(timeout_kind, timeout)
+        remaining = check_deadline!(timeout_kind, timeout)
+        
+        if remaining < timeout
+          timeout_kind = :request
+          timeout = remaining
+        end
       end
 
       select = case type
@@ -348,9 +353,7 @@ module Excon
       
       raise(Excon::Errors::Timeout.new('request timeout reached')) if now >= deadline
 
-      remaining  = deadline - now
-
-      remaining < timeout ? [:request, remaining] : [type, timeout]
+      deadline - now
     end
   end
 end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -63,7 +63,7 @@ describe Excon::Connection do
       let(:timeout) { 0.001 }
   
       it 'returns a Excon::Error::Timeout' do
-        expect { conn.request(:path => '/sloth') }.to raise_error(Excon::Error::Timeout)
+        expect { conn.request(:path => '/sloth') }.to raise_error(Excon::Error::Timeout, 'request timeout reached')
       end
     end
   end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -24,8 +24,8 @@ describe Excon::Connection do
     context 'when timeout is triggered' do
       let(:timeout) { 0.001 }
 
-      it 'returns a Excon::Error::Timeout' do
-        expect { conn.request(:path => '/sloth') }.to raise_error(Excon::Error::Timeout)
+      it 'does not error' do
+        expect(conn.request(:path => '/sloth').status).to eq(200)
       end
     end
   end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -15,10 +15,20 @@ describe Excon::Connection do
   context "blocking connection" do
     let (:nonblock) { false }
 
-    context 'when timeout is not triggered' do 
-      let(:timeout) { 120 }
+    context 'when timeout is not set' do
+      let(:timeout) { nil }
+  
+      it 'does not error' do
+        expect(conn.request(:path => '/content-length/100').status).to eq(200)
+      end
+    end
 
-      include_examples 'a basic client'
+    context 'when timeout is not triggered' do 
+      let(:timeout) { 1 }
+
+      it 'does not error' do
+        expect(conn.request(:path => '/content-length/100').status).to eq(200)        
+      end
     end
   
     context 'when timeout is triggered' do
@@ -33,10 +43,20 @@ describe Excon::Connection do
   context "non-blocking connection" do
     let (:nonblock) { true }
 
-    context 'when timeout is not triggered' do
-      let(:timeout) { 120 }
+    context 'when timeout is not set' do
+      let(:timeout) { nil }
   
-      include_examples 'a basic client'
+      it 'does not error' do
+        expect(conn.request(:path => '/content-length/100').status).to eq(200)        
+      end
+    end
+
+    context 'when timeout is not triggered' do
+      let(:timeout) { 1 }
+  
+      it 'does not error' do
+        expect(conn.request(:path => '/content-length/100').status).to eq(200)        
+      end
     end
   
     context 'when timeout is triggered' do

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -34,7 +34,7 @@ describe Excon::Connection do
     end
   
     context 'when timeout is triggered' do
-      let(:read_timeout) { 5 }
+      let(:read_timeout) { 0.005 }
       let(:timeout) { 0.001 }
   
       it 'does not raise' do

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -66,7 +66,7 @@ describe Excon::Connection do
     context 'when timeout is triggered' do
       let(:timeout) { 0.001 }
   
-      it 'returns a Excon::Error::Timeout' do
+      it 'returns a request Excon::Error::Timeout' do
         expect { conn.request(:path => '/timeout') }.to raise_error(Excon::Error::Timeout, 'request timeout reached')
       end
     end
@@ -75,7 +75,7 @@ describe Excon::Connection do
       let(:read_timeout) { 0.001 }
       let(:timeout) { 0.005 }
   
-      it 'returns a Excon::Error::Timeout' do
+      it 'returns a read Excon::Error::Timeout' do
         expect { conn.request(:path => '/timeout') }.to raise_error(Excon::Error::Timeout, 'read timeout reached')
       end
     end

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -21,7 +21,7 @@ describe Excon::Connection do
       let(:timeout) { nil }
   
       it 'does not error' do
-        expect(conn.request(:path => '/').status).to eq(200)
+        expect(conn.request(:path => '/no-timeout').status).to eq(200)
       end
     end
 
@@ -29,7 +29,7 @@ describe Excon::Connection do
       let(:timeout) { 1 }
 
       it 'does not error' do
-        expect(conn.request(:path => '/').status).to eq(200)        
+        expect(conn.request(:path => '/no-timeout').status).to eq(200)        
       end
     end
   
@@ -51,7 +51,7 @@ describe Excon::Connection do
       let(:timeout) { nil }
   
       it 'does not error' do
-        expect(conn.request(:path => '/').status).to eq(200)        
+        expect(conn.request(:path => '/no-timeout').status).to eq(200)        
       end
     end
 
@@ -59,7 +59,7 @@ describe Excon::Connection do
       let(:timeout) { 1 }
   
       it 'does not error' do
-        expect(conn.request(:path => '/').status).to eq(200)        
+        expect(conn.request(:path => '/no-timeout').status).to eq(200)        
       end
     end
   

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -34,7 +34,7 @@ describe Excon::Connection do
     end
   
     context 'when timeout is triggered' do
-      let(:read_timeout) { 0.005 }
+      let(:read_timeout) { 5 }
       let(:timeout) { 0.001 }
   
       it 'does not raise' do
@@ -73,7 +73,7 @@ describe Excon::Connection do
 
     context 'when read timeout is triggered' do
       let(:read_timeout) { 0.001 }
-      let(:timeout) { 0.005 }
+      let(:timeout) { 5 }
   
       it 'returns a read Excon::Error::Timeout' do
         expect { conn.request(:path => '/timeout') }.to raise_error(Excon::Error::Timeout, 'read timeout reached')

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Excon::Connection do
+  include_context('test server', :webrick, 'basic.ru', before: :start, after: :stop)
+
+  let(:conn) do
+    Excon::Connection.new(host: '127.0.0.1',
+                          hostname: '127.0.0.1',
+                          nonblock: nonblock,
+                          port: 9292,
+                          scheme: 'http',
+                          timeout: timeout)
+  end
+
+  context "blocking connection" do
+    let (:nonblock) { false }
+
+    context 'when timeout is not triggered' do 
+      let(:timeout) { 120 }
+
+      include_examples 'a basic client'
+    end
+  
+    context 'when timeout is triggered' do
+      let(:timeout) { 0.001 }
+
+      it 'returns a Excon::Error::Timeout' do
+        expect { conn.request(:path => '/sloth') }.to raise_error(Excon::Error::Timeout)
+      end
+    end
+  end
+
+  context "non-blocking connection" do
+    let (:nonblock) { true }
+
+    context 'when timeout is not triggered' do
+      let(:timeout) { 120 }
+  
+      include_examples 'a basic client'
+    end
+  
+    context 'when timeout is triggered' do
+      let(:timeout) { 0.001 }
+  
+      it 'returns a Excon::Error::Timeout' do
+        expect { conn.request(:path => '/sloth') }.to raise_error(Excon::Error::Timeout)
+      end
+    end
+  end
+end

--- a/tests/rackups/basic.rb
+++ b/tests/rackups/basic.rb
@@ -43,11 +43,6 @@ class Basic < Sinatra::Base
     'bar'
   end
 
-  get('/sloth') do
-    sleep 0.005 # 5 milliseconds
-    'sloth'
-  end
-
   private
 
   def echo

--- a/tests/rackups/basic.rb
+++ b/tests/rackups/basic.rb
@@ -43,6 +43,11 @@ class Basic < Sinatra::Base
     'bar'
   end
 
+  get('/sloth') do
+    sleep 0.005 # 5 milliseconds
+    'sloth'
+  end
+
   private
 
   def echo

--- a/tests/rackups/timeout.ru
+++ b/tests/rackups/timeout.ru
@@ -4,6 +4,10 @@ class App < Sinatra::Base
   set :environment, :production
   enable :dump_errors
 
+  get('/') do
+    ''
+  end
+
   get('/timeout') do
     sleep(2)
     ''

--- a/tests/rackups/timeout.ru
+++ b/tests/rackups/timeout.ru
@@ -4,7 +4,7 @@ class App < Sinatra::Base
   set :environment, :production
   enable :dump_errors
 
-  get('/') do
+  get('/no-timeout') do
     ''
   end
 


### PR DESCRIPTION
Closes https://github.com/excon/excon/issues/596

## Approach
Today, blocking connections do not have connect or write timeouts (only read timeouts). Therefore, the request timeout only applies to non-blocking connections. The expectation seems to be that for a blocking connection, the caller is wrapping `Excon` requests in a `Timeout.timeout` block.

One of the goals of this implementation is to minimize the cost to requests not using a timeout. Therefore, the clock is not queried and the deadline is not checked unless a timeout is defined.

I used `Process.clock_gettime(Process::CLOCK_MONOTONIC)` instead of `Time.now` to avoid the added cost of allocating a Time object and to ensure that we track request deadlines correctly (i.e. not affected by clock sync).

For the timeout kinds, I chose to use a Hash mapping `type` to timeout instead of a method because a micro-benchmark I wrote showed the hash approach was ~2x faster.

## Testing
All existing tests pass and I added some tests for both blocking and non-blocking sockets.