### PR TITLE
Performance improvement on nonblocking sockets

### DIFF
--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -176,7 +176,7 @@ module Excon
             end
           else
             if response_block
-              while (chunk = socket.read_chunk(datum[:chunk_size]))
+              while (chunk = socket.read(datum[:chunk_size]))
                 response_block.call(chunk, nil, nil)
               end
             else

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -163,7 +163,7 @@ module Excon
           if (remaining = content_length)
             if response_block
               while remaining > 0
-                chunk = socket.read([datum[:chunk_size], remaining].min) || raise(EOFError)
+                chunk = socket.read_chunk([datum[:chunk_size], remaining].min) || raise(EOFError)
                 response_block.call(chunk, [remaining - chunk.bytesize, 0].max, content_length)
                 remaining -= chunk.bytesize
               end
@@ -176,7 +176,7 @@ module Excon
             end
           else
             if response_block
-              while (chunk = socket.read(datum[:chunk_size]))
+              while (chunk = socket.read_chunk(datum[:chunk_size]))
                 response_block.call(chunk, nil, nil)
               end
             else

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -130,7 +130,7 @@ module Excon
           if response_block
             while (chunk_size = socket.readline.chomp!.to_i(16)) > 0
               while chunk_size > 0
-                chunk = socket.read(chunk_size) || raise(EOFError)
+                chunk = socket.read_chunk(chunk_size) || raise(EOFError)
                 chunk_size -= chunk.bytesize
                 response_block.call(chunk, nil, nil)
               end

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -163,7 +163,7 @@ module Excon
           if (remaining = content_length)
             if response_block
               while remaining > 0
-                chunk = socket.read_chunk([datum[:chunk_size], remaining].min) || raise(EOFError)
+                chunk = socket.read_chunk([datum[:chunk_size], remaining].min, false) || raise(EOFError)
                 response_block.call(chunk, [remaining - chunk.bytesize, 0].max, content_length)
                 remaining -= chunk.bytesize
               end
@@ -176,7 +176,7 @@ module Excon
             end
           else
             if response_block
-              while (chunk = socket.read(datum[:chunk_size]))
+              while (chunk = socket.read_chunk(datum[:chunk_size], false))
                 response_block.call(chunk, nil, nil)
               end
             else

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -237,14 +237,15 @@ module Excon
       end
     end
 
-    # Drains the socket of any remaning bytes. This emulates the behavior of a blocking read with no max_length.
+    # Drains the socket of any remaining bytes. This emulates the behavior of a blocking read with no max_length.
     # Returns the read bytes.
     def drain(block)
       chunk_size = @data[:chunk_size]
-      result = String.new
+      result = read_nonblock(chunk_size, block)
 
-      while chunk = read_nonblock(chunk_size, block)
-        result << chunk
+      until @eof
+        chunk = read_nonblock(chunk_size, block)
+        result << chunk if chunk
       end
 
       result

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -75,12 +75,18 @@ module Excon
       result = String.new
       remaining = chunk_size
 
-      while remaining > 0 && chunk = read(remaining)
+      while remaining > 0
+        chunk = read(remaining)
+
+        if chunk.nil?
+          break
+        end
+
         remaining -= chunk.length
         result << chunk
       end
 
-      result
+      result.empty? ? nil : result
     end
 
     def readline

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -47,7 +47,6 @@ module Excon
 
     def_delegators(:@socket, :close)
 
-
     def initialize(data = {})
       @data = data
       @nonblock = data[:nonblock]

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -76,18 +76,9 @@ module Excon
       result = String.new
       remaining = chunk_size
 
-      while remaining > 0 && chunk = read(chunk_size)
-        if chunk.length > remaining
-          # Seek the read buffer to just after the newline.
-          # The offset is moved back to the start of the current chunk and then forward until we consume the remaining bytes.
-          @read_offset = @read_offset - chunk.length + remaining
-
-          remaining = 0
-          result << chunk[..remaining]
-        else
-          remaining -= chunk.length
-          result << chunk
-        end
+      while remaining > 0 && chunk = read(remaining)
+        remaining -= chunk.length
+        result << chunk
       end
 
       result

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -97,7 +97,12 @@ module Excon
         result = String.new
 
         loop do
-          chunk = read(@data[:chunk_size]) || raise(EOFError)
+          if @eof
+            raise(EOFError)
+          end
+
+          chunk = read(@data[:chunk_size])
+
           idx = chunk.index("\n")
 
           if idx.nil?

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -75,12 +75,10 @@ module Excon
       result = String.new
       remaining = chunk_size
 
-      while remaining > 0
+      while remaining.positive?
         chunk = read(remaining)
 
-        if chunk.nil?
-          break
-        end
+        break if chunk.nil? || chunk.empty?
 
         remaining -= chunk.length
         result << chunk

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -71,6 +71,27 @@ module Excon
       end
     end
 
+    # Reads the socket in chunks. Waits until the given chunk size is avaialble or end of file is reached.
+    def read_chunk(chunk_size)
+      result = String.new
+      remaining = chunk_size
+
+      while remaining > 0 && chunk = read(chunk_size)
+        if chunk.length > remaining
+          # Seek the read buffer to just after the newline.
+          # The offset is moved back to the start of the current chunk and then forward until we consume the remaining bytes.
+          @read_offset = @read_offset - chunk.length + remaining
+
+          remaining = 0
+          result << chunk[..remaining]
+        else
+          remaining -= chunk.length
+          result << chunk
+        end
+      end
+
+      result
+    end
 
     def readline
       if @nonblock

--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -54,15 +54,17 @@ module Excon
       @read_buffer = ''.b
       @read_offset = 0
       @eof = false
-      
+
       connect
     end
 
     def read(max_length = nil)
       if @eof
         max_length ? nil : ''
-      elsif @nonblock
+      elsif @nonblock && max_length
         read_nonblock(max_length)
+      elsif @nonblock
+        drain
       else
         read_block(max_length)
       end
@@ -241,8 +243,6 @@ module Excon
     # Reads up to max_length bytes. Returns nil on end of file.
     # Reads are buffered and no system calls will be made until the buffer is fully consumed.
     def read_nonblock(max_length)
-      return drain unless max_length
-
       begin
         if @read_offset >= @read_buffer.length
           # Clear the buffer so we can test for emptiness in the rescue blocks

--- a/tests/socket_tests.rb
+++ b/tests/socket_tests.rb
@@ -70,8 +70,7 @@ class MockNonblockRubySocket
 end
 
 Shindo.tests('socket') do
-  CHUNK_SIZES = [nil, 512]
-  CHUNK_SIZES.each do |chunk_size|
+  [nil, 512].each do |chunk_size|
     tests("chunk_size: #{chunk_size}") do
       socket_args = {chunk_size: chunk_size}
       tests('read_nonblock') do

--- a/tests/socket_tests.rb
+++ b/tests/socket_tests.rb
@@ -32,7 +32,7 @@ class MockNonblockRubySocket
     @sequence = []
   end
 
-  def read_nonblock(maxlen)
+  def read_nonblock(maxlen, buffer = nil)
     if @nonblock_reads.empty?
       @sequence << 'EOF'
       raise EOFError
@@ -48,7 +48,14 @@ class MockNonblockRubySocket
       len = maxlen ? maxlen : @nonblock_reads.first.length
       ret = @nonblock_reads.first.slice!(0, len)
       @sequence << ret.length
-      ret
+
+      if buffer
+        buffer.clear
+        buffer << ret
+        buffer
+      else
+        ret
+      end
     end
   end
 


### PR DESCRIPTION
The goal of this change is to further reduce the allocations and system calls for a small number of bytes. By fully consuming the read buffer before reading more bytes, we can avoid making system calls to request less than `max_length` bytes.

In order to handle the streaming with a response block cases, I had to add a `block` argument to `Socket#read`. This allowed me to denote whether I wanted to wait for bytes to be avialable or not. That together with a new `Socket#read_chunk` that tries to read a full `chunk_size` bytes helped me get tests passing.