### PR TITLE
Performance improvement on nonblocking sockets

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -53,14 +53,16 @@ module Excon
       @nonblock = data[:nonblock]
       @port ||= @data[:port] || 80
       @read_buffer = String.new
+      @read_offset = 0
       @eof = false
       @backend_eof = false
+
       connect
     end
 
     def read(max_length = nil)
       if @eof
-        return max_length ? nil : ''
+        max_length ? nil : ''
       elsif @nonblock
         read_nonblock(max_length)
       else
@@ -71,20 +73,22 @@ module Excon
     def readline
       if @nonblock
         result = String.new
-        block = @read_buffer
-        @read_buffer = String.new
+        block = consume_read_buffer
 
         loop do
           idx = block.index("\n")
+
           if idx.nil?
             result << block
           else
-            result << block.slice!(0, idx+1)
-            add_to_read_buffer(block)
+            result << block[..idx]
+            add_to_read_buffer(block, idx)
             break
           end
+
           block = read_nonblock(@data[:chunk_size]) || raise(EOFError)
         end
+
         result
       else # nonblock/legacy
         begin
@@ -204,19 +208,37 @@ module Excon
       end
     end
 
-    def add_to_read_buffer(str)
-      @read_buffer << str
+    # Consume any bytes remaining in the read buffer before making a system call.
+    def consume_read_buffer
+      block = @read_buffer[@read_offset..]
+
+      @read_offset = @read_buffer.length
+
+      block
+    end
+
+    # Seek the read buffer to just after the given index.
+    # The offset is moved back to the start of the current chunk and then forward until just after the index.
+    def add_to_read_buffer(chunk, idx)
+      @read_offset = @read_offset - chunk.length + (idx + 1)
       @eof = false
     end
 
     def read_nonblock(max_length)
       begin
+        if @read_offset != 0 && @read_offset >= @read_buffer.length
+          # Clear the buffer so we can test for emptiness below
+          @read_buffer.clear
+          # Reset the offset so it matches the length of the buffer when empty.
+          @read_offset = 0
+        end
+
         if max_length
-          until @backend_eof || @read_buffer.length >= max_length
+          until @backend_eof || (@read_buffer.length - @read_offset) >= max_length
             if @read_buffer.empty?
               @read_buffer = @socket.read_nonblock(max_length, @read_buffer)
             else
-              @read_buffer << @socket.read_nonblock(max_length - @read_buffer.length)
+              @read_buffer << @socket.read_nonblock(max_length - (@read_buffer.length - @read_offset))
             end
           end
         else
@@ -245,18 +267,29 @@ module Excon
         @backend_eof = true
       end
 
-      ret = if max_length
+      if max_length
         if @read_buffer.empty?
-          nil # EOF met at beginning
+          # EOF met at beginning
+          @eof = @backend_eof
+          nil
         else
-          @read_buffer.slice!(0, max_length)
+          start = @read_offset
+          bytes_to_read = @read_buffer.length - @read_offset
+
+          # Ensure that we can seek backwards when reading until a terminator string.
+          # The read offset must never point past the end of the read buffer.
+          @read_offset += max_length > bytes_to_read ? bytes_to_read : max_length
+          @read_buffer[start...@read_offset]
         end
       else
         # read until EOFError, so return everything
-        @read_buffer.slice!(0, @read_buffer.length)
+        start = @read_offset
+
+        @read_offset = @read_buffer.length
+        @eof = @backend_eof
+
+        @read_buffer[start..]
       end
-      @eof = @backend_eof && @read_buffer.empty?
-      ret
     end
 
     def read_block(max_length)

--- a/tests/socket_tests.rb
+++ b/tests/socket_tests.rb
@@ -32,7 +32,7 @@ class MockNonblockRubySocket
     @sequence = []
   end
 
-  def read_nonblock(maxlen)
+  def read_nonblock(maxlen, buffer = nil)
     if @nonblock_reads.empty?
       @sequence << 'EOF'
       raise EOFError
@@ -48,7 +48,14 @@ class MockNonblockRubySocket
       len = maxlen ? maxlen : @nonblock_reads.first.length
       ret = @nonblock_reads.first.slice!(0, len)
       @sequence << ret.length
-      ret
+
+      if buffer
+        buffer.clear
+        buffer << ret
+        buffer
+      else
+        ret
+      end
     end
   end
 


### PR DESCRIPTION
The goal of this change is to improve the performance of excon while maintaining a low number of allocations.

This change is similar in nature to what `Net::HTTP` does in https://github.com/ruby/ruby/blob/v3_2_2/lib/net/protocol.rb#L166 . 

The following is a zipped archive of 3 ruby-prof profiles measuring allocations. From the profiles, it is evident the number of allocations in OpenSSL calls and Socket calls remains very similar (still significantly less than v0.71.0).

[Excon.zip](https://github.com/excon/excon/files/13433081/Excon.zip)

Results from my benchmark show this is a marked improvement from the latest version:
```
Modified:      377.9 i/s
v0.104.0:      258.3 i/s
v0.71.0:       364.4 i/s
```