### PR TITLE
Use Resolv::DefaultResolver when no resolv_resolver is set.

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -132,14 +132,14 @@ module Excon
         family = @data[:proxy][:family]
       end
 
-      resolver = @data[:resolv_resolver] || Resolv.new
+      resolver = @data[:resolv_resolver] || Resolv::DefaultResolver
 
       # Deprecated
       if @data[:dns_timeouts]
         Excon.display_warning('dns_timeouts is deprecated, use resolv_resolver instead.')
         dns_resolver = Resolv::DNS.new
         dns_resolver.timeouts = @data[:dns_timeouts]
-        resolver = Resolv.new([Resolv::Hosts.new, dns_resolver])  
+        resolver = Resolv.new([Resolv::Hosts.new, dns_resolver])
       end
 
       resolver.each_address(hostname) do |ip|


### PR DESCRIPTION
Hey there! This is a follow up to: 
* https://github.com/excon/excon/pull/834
* https://github.com/excon/excon/issues/832

Back in #832 this suggestion was made by @geemus:

> By default we could configure excon then to still use `Resolv::DefaultResolver` or instead use the specified resolvers.

But then it was not implemented this way at #834. This PR changes the default Excon resolver to `Resolv::DefaultResolver` instead of `Resolv.new`.

<details>
  <summary>See why this is important</summary>

```ruby
require 'resolv'

Resolv::DefaultResolver.replace_resolvers(
  [
    Resolv::Hosts.new,
    Resolv::MDNS.new,
    Resolv::DNS.new
  ]
)

pp Resolv::DefaultResolver
# #<Resolv:0x000055f2d6089a70
#  @resolvers=
#   [#<Resolv::Hosts:0x000055f2d6089688
#     @filename="/etc/hosts",
#     @initialized=nil,
#     @mutex=#<Thread::Mutex:0x000055f2d6089660>>,
#    #<Resolv::MDNS:0x000055f2d6089638
#     @config=
#      #<Resolv::DNS::Config:0x000055f2d60895c0
#       @config_info=
#        {:nameserver_port=>[["224.0.0.251", 5353], ["ff02::fb", 5353]]},
#       @initialized=nil,
#       @mutex=#<Thread::Mutex:0x000055f2d6089598>,
#       @timeouts=nil>,
#     @initialized=nil,
#     @mutex=#<Thread::Mutex:0x000055f2d60895e8>>,
#    #<Resolv::DNS:0x000055f2d6089570
#     @config=
#      #<Resolv::DNS::Config:0x000055f2d6089520
#       @config_info=nil,
#       @initialized=nil,
#       @mutex=#<Thread::Mutex:0x000055f2d60894f8>,
#       @timeouts=nil>,
#     @initialized=nil,
#     @mutex=#<Thread::Mutex:0x000055f2d6089548>>]>

pp Resolv.new
# #<Resolv:0x000055f2d60d3f30
#  @resolvers=
#   [#<Resolv::Hosts:0x000055f2d60d3f08
#     @filename="/etc/hosts",
#     @initialized=nil,
#     @mutex=#<Thread::Mutex:0x000055f2d60d3ee0>>,
#    #<Resolv::DNS:0x000055f2d60d3eb8
#     @config=
#      #<Resolv::DNS::Config:0x000055f2d60d3e68
#       @config_info=nil,
#       @initialized=nil,
#       @mutex=#<Thread::Mutex:0x000055f2d60d3e40>,
#       @timeouts=nil>,
#     @initialized=nil,
#     @mutex=#<Thread::Mutex:0x000055f2d60d3e90>>]>
```
</details>
