### PR TITLE
Require at least Ruby 2.7 for future excon releases

### DIFF
--- a/excon.gemspec
+++ b/excon.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
     "README.md",
     "excon.gemspec"
   ]
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_development_dependency('rspec', '>= 3.5.0')
   s.add_development_dependency('activesupport')


### PR DESCRIPTION
To avoid problems like https://github.com/excon/excon/issues/843

Discussed at https://github.com/excon/excon/pull/844#issuecomment-1876931461