### PR TITLE
Deprecate omit_default_port option, add include_default_port option

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ connection.request(:timeout => 0.1) # timeout if the entire request takes longer
 #
 connection = Excon.new('http://geemus.com/', :tcp_nodelay => true)
 
+# opt-in to having Excon add a default port (http:80 and https:443)
+connection = Excon.new('http://geemus.com/', :include_default_port => true)
+
 # set longer connect_timeout (default is 60 seconds)
 connection = Excon.new('http://geemus.com/', :connect_timeout => 360)
 

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -446,7 +446,7 @@ module Excon
         raise ArgumentError.new("Invalid validation type '#{validation}'")
       end
 
-      if validation == :connection && datum[:omit_default_port] != true
+      if validation == :connection && params[:omit_default_port] != true
         Excon.display_warning(
           'The `omit_default_port` connection option is deprecated, please use `include_default_port` instead.'
         )

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -446,6 +446,12 @@ module Excon
         raise ArgumentError.new("Invalid validation type '#{validation}'")
       end
 
+      if validation == :connection && datum[:omit_default_port] != true
+        Excon.display_warning(
+          'The `omit_default_port` connection option is deprecated, please use `include_default_port` instead.'
+        )
+      end
+
       invalid_keys = params.keys - valid_keys
       unless invalid_keys.empty?
         Excon.display_warning("Invalid Excon #{validation} keys: #{invalid_keys.map(&:inspect).join(', ')}")

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -160,7 +160,7 @@ module Excon
     mock: false,
     include_default_port: false,
     nonblock: true,
-    omit_default_port: false,
+    omit_default_port: true,
     persistent: false,
     read_timeout: 60,
     resolv_resolver: nil,

--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -84,6 +84,7 @@ module Excon
     keepalive
     host
     hostname
+    include_default_port
     omit_default_port
     nonblock
     reuseaddr
@@ -157,6 +158,7 @@ module Excon
       Excon::Middleware::Mock
     ],
     mock: false,
+    include_default_port: false,
     nonblock: true,
     omit_default_port: false,
     persistent: false,

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -108,7 +108,7 @@ module Excon
       end
 
       if @data[:proxy]
-        request = "CONNECT #{@data[:host]}#{port_string(@data.merge(:omit_default_port => false))}#{Excon::HTTP_1_1}" +
+        request = "CONNECT #{@data[:host]}#{Excon::HTTP_1_1}" \
                   "Host: #{@data[:host]}#{port_string(@data)}#{Excon::CR_NL}"
 
         if @data[:proxy].has_key?(:user) || @data[:proxy].has_key?(:password)

--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -62,10 +62,10 @@ module Excon
     end
 
     def port_string(datum)
-      if datum[:port].nil? || (datum[:omit_default_port] && ((datum[:scheme].casecmp('http') == 0 && datum[:port] == 80) || (datum[:scheme].casecmp('https') == 0 && datum[:port] == 443)))
-        ''
+      if datum[:include_default_port] || !default_port?(datum)
+        ':' << datum[:port].to_s
       else
-        ':' + datum[:port].to_s
+        ''
       end
     end
 
@@ -84,6 +84,11 @@ module Excon
       end
 
       params
+    end
+
+    def default_port?(datum)
+      (datum[:scheme].casecmp('http') == 0 && datum[:port] == 80) ||
+        (datum[:scheme].casecmp('https') == 0 && datum[:port] == 443)
     end
 
     def query_string(datum)

--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -62,8 +62,8 @@ module Excon
     end
 
     def port_string(datum)
-      if datum[:include_default_port] || !default_port?(datum)
-        ':' << datum[:port].to_s
+      if !default_port?(datum) || datum[:include_default_port] || !datum[:omit_default_port]
+        ":#{datum[:port]}"
       else
         ''
       end
@@ -87,8 +87,8 @@ module Excon
     end
 
     def default_port?(datum)
-      (datum[:scheme].casecmp('http') == 0 && datum[:port] == 80) ||
-        (datum[:scheme].casecmp('https') == 0 && datum[:port] == 443)
+      (datum[:scheme].casecmp('http').zero? && datum[:port] == 80) ||
+        (datum[:scheme].casecmp('https').zero? && datum[:port] == 443)
     end
 
     def query_string(datum)

--- a/tests/utils_tests.rb
+++ b/tests/utils_tests.rb
@@ -1,15 +1,14 @@
+# frozen_string_literal: true
+
 Shindo.tests('Excon::Utils') do
-
   tests('#connection_uri') do
-
     expected_uri = 'unix:///tmp/some.sock'
     tests('using UNIX scheme').returns(expected_uri) do
-      connection = Excon.new('unix:///some/path', :socket => '/tmp/some.sock')
+      connection = Excon.new('unix:///some/path', socket: '/tmp/some.sock')
       Excon::Utils.connection_uri(connection.data)
     end
 
     tests('using HTTP scheme') do
-
       expected_uri = 'http://foo.com'
       tests('without default port').returns(expected_uri) do
         connection = Excon.new('http://foo.com/some/path')
@@ -17,13 +16,23 @@ Shindo.tests('Excon::Utils') do
       end
 
       expected_uri = 'http://foo.com:80'
-      tests('without default port').returns(expected_uri) do
-        connection = Excon.new('http://foo.com/some/path', :include_default_port => true)
+      tests('include_default_port adds default port').returns(expected_uri) do
+        connection = Excon.new('http://foo.com/some/path', include_default_port: true)
         Excon::Utils.connection_uri(connection.data)
       end
 
-    end
+      expected_uri = 'http://foo.com'
+      tests('!include_default_port has no port value').returns(expected_uri) do
+        connection = Excon.new('http://foo.com/some/path', include_default_port: false)
+        Excon::Utils.connection_uri(connection.data)
+      end
 
+      expected_uri = 'http://foo.com'
+      tests('omit_default_port has no port value').returns(expected_uri) do
+        connection = Excon.new('http://foo.com/some/path', omit_default_port: true)
+        Excon::Utils.connection_uri(connection.data)
+      end
+    end
   end
 
   tests('#request_uri') do

--- a/tests/utils_tests.rb
+++ b/tests/utils_tests.rb
@@ -10,15 +10,15 @@ Shindo.tests('Excon::Utils') do
 
     tests('using HTTP scheme') do
 
-      expected_uri = 'http://foo.com:80'
-      tests('with default port').returns(expected_uri) do
+      expected_uri = 'http://foo.com'
+      tests('without default port').returns(expected_uri) do
         connection = Excon.new('http://foo.com/some/path')
         Excon::Utils.connection_uri(connection.data)
       end
 
-      expected_uri = 'http://foo.com'
+      expected_uri = 'http://foo.com:80'
       tests('without default port').returns(expected_uri) do
-        connection = Excon.new('http://foo.com/some/path', :omit_default_port => true)
+        connection = Excon.new('http://foo.com/some/path', :include_default_port => true)
         Excon::Utils.connection_uri(connection.data)
       end
 
@@ -48,22 +48,66 @@ Shindo.tests('Excon::Utils') do
 
     tests('using HTTP scheme') do
 
-      expected_uri = 'http://foo.com:80/some/path'
+      expected_uri = 'http://foo.com/some/path'
       tests('without query').returns(expected_uri) do
         connection = Excon.new('http://foo.com')
         params = { :path => '/some/path' }
         Excon::Utils.request_uri(connection.data.merge(params))
       end
 
-      expected_uri = 'http://foo.com:80/some/path?bar=that&foo=this'
+      expected_uri = 'http://foo.com/some/path?bar=that&foo=this'
       tests('with query').returns(expected_uri) do
         connection = Excon.new('http://foo.com')
         params = { :path => '/some/path', :query => { :foo => 'this', :bar => 'that' } }
         Excon::Utils.request_uri(connection.data.merge(params))
       end
-
     end
 
+    test('detecting default ports') do
+      tests('http default port').returns true do
+        datum = {
+          scheme: 'http',
+          port: 80
+        }
+
+        Excon::Utils.default_port?(datum)
+      end
+
+      tests('http nonstandard port').returns false do
+        datum = {
+          scheme: 'http',
+          port: 9292
+        }
+
+        Excon::Utils.default_port?(datum)
+      end
+
+      tests('https standard port').returns true do
+        datum = {
+          scheme: 'https',
+          port: 443
+        }
+
+        Excon::Utils.default_port?(datum)
+      end
+
+      tests('https nonstandard port').returns false do
+        datum = {
+          scheme: 'https',
+          port: 8443
+        }
+
+        Excon::Utils.default_port?(datum)
+      end
+
+      tests('unix socket').returns false do
+        datum = {
+          scheme: 'unix'
+        }
+
+        Excon::Utils.default_port?(datum)
+      end
+    end
   end
 
   tests('#escape_uri').returns('/hello%20excon') do


### PR DESCRIPTION
- Port being added to URL can be forced by using include_default_port option
- Simplifies some of the port addition code
- Break out logic to determine if a default port is logic into its own method
- Tests basic cases of scheme+port combinations
