### PR TITLE
handle empty content-encoding header in decompress middleware

### DIFF
--- a/lib/excon/middlewares/decompress.rb
+++ b/lib/excon/middlewares/decompress.rb
@@ -19,14 +19,14 @@ module Excon
         if !(datum.key?(:response_block) || body.nil? || body.empty?) &&
            (key = datum[:response][:headers].keys.detect { |k| k.casecmp('Content-Encoding').zero? })
           encodings = Utils.split_header_value(datum[:response][:headers][key])
-          if encodings.last.casecmp('deflate').zero?
+          if encodings&.last&.casecmp('deflate')&.zero?
             datum[:response][:body] = begin
               Zlib::Inflate.new(INFLATE_ZLIB_OR_GZIP).inflate(body)
             rescue Zlib::DataError # fallback to raw on error
               Zlib::Inflate.new(INFLATE_RAW).inflate(body)
             end
             encodings.pop
-          elsif encodings.last.casecmp('gzip').zero? || encodings.last.casecmp('x-gzip').zero?
+          elsif encodings&.last&.casecmp('gzip')&.zero? || encodings&.last&.casecmp('x-gzip')&.zero?
             datum[:response][:body] = Zlib::GzipReader.new(StringIO.new(body)).read
             encodings.pop
           end

--- a/tests/middlewares/decompress_tests.rb
+++ b/tests/middlewares/decompress_tests.rb
@@ -171,5 +171,17 @@ Shindo.tests('Excon Decompress Middleware') do
 
   end
 
+  tests('empty content-encoding') do
+    Excon.stub({ method: :get }, { body: 'body', headers: { 'Content-Encoding' => '' }, status: 200 })
+
+    tests('succeeds').returns('body') do
+      connection = Excon.new('http://example.com', mock: true)
+      resp = connection.request(method: :get)
+      resp[:body]
+    end
+
+    Excon.stubs.clear
+  end
+
   env_restore
 end


### PR DESCRIPTION
fixes #862 