### PR TITLE
Use casecmp? instead of casecmp() == 0

### DIFF
--- a/benchmarks/downcase-eq-eq_vs_casecmp.rb
+++ b/benchmarks/downcase-eq-eq_vs_casecmp.rb
@@ -31,25 +31,25 @@ Benchmark.bmbm do |x|
 
   x.report('casecmp1') do
     iters.times.each do
-      hello.casecmp(comp).zero?
+      hello.casecmp?(comp)
     end
   end
 
   x.report('casecmp1-1') do
     iters.times.each do
-      hello.casecmp(comp) == 0
+      hello.casecmp?(comp)
     end
   end
 
   x.report('casecmp2') do
     iters.times.each do
-      "HelLo".casecmp(comp).zero?
+      "HelLo".casecmp?(comp)
     end
   end
 
   x.report('casecmp2-1') do
     iters.times.each do
-      "HelLo".casecmp(comp) == 0
+      "HelLo".casecmp?(comp)
     end
   end
 end

--- a/benchmarks/headers_case_sensitivity.rb
+++ b/benchmarks/headers_case_sensitivity.rb
@@ -23,9 +23,9 @@ Formatador.indent do
       until ((data = socket.readline).chop!).empty?
         key, value = data.split(': ')
         headers[key] = value
-        (key.casecmp('Transfer-Encoding') == 0) && (value.casecmp('chunked') == 0)
-        (key.casecmp('Connection') == 0) && (value.casecmp('close') == 0)
-        (key.casecmp('Content-Length') == 0)
+        key.casecmp?('Transfer-Encoding') && value.casecmp?('chunked')
+        key.casecmp?('Connection') && value.casecmp?('close')
+        key.casecmp?('Content-Length')
       end
     end
 
@@ -35,8 +35,8 @@ Formatador.indent do
         key, value = data.split(': ')
         headers[key] = value
       end
-      headers.has_key?('Transfer-Encoding') && headers['Transfer-Encoding'].casecmp('chunked') == 0
-      headers.has_key?('Connection') && headers['Connection'].casecmp('close') == 0
+      headers.has_key?('Transfer-Encoding') && headers['Transfer-Encoding'].casecmp?('chunked')
+      headers.has_key?('Connection') && headers['Connection'].casecmp?('close')
       headers.has_key?('Content-Length')
     end
   end
@@ -63,9 +63,9 @@ Formatador.indent do
       until ((data = socket.readline).chop!).empty?
         key, value = data.split(': ')
         headers[key] = value
-        (key.casecmp('Transfer-Encoding') == 0) && (value.casecmp('chunked') == 0)
-        (key.casecmp('Connection') == 0) && (value.casecmp('close') == 0)
-        (key.casecmp('Content-Length') == 0)
+        key.casecmp?('Transfer-Encoding') && value.casecmp?('chunked')
+        key.casecmp?('Connection') && value.casecmp?('close')
+        key.casecmp?('Content-Length')
       end
     end
 
@@ -75,8 +75,8 @@ Formatador.indent do
         key, value = data.split(': ')
         headers[key] = value
       end
-      headers.has_key?('Transfer-Encoding') && headers['Transfer-Encoding'].casecmp('chunked') == 0
-      headers.has_key?('Connection') && headers['Connection'].casecmp('close') == 0
+      headers.has_key?('Transfer-Encoding') && headers['Transfer-Encoding'].casecmp?('chunked')
+      headers.has_key?('Connection') && headers['Connection'].casecmp?('close')
       headers.has_key?('Content-Length')
     end
   end

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -138,7 +138,7 @@ module Excon
 
             # The HTTP spec isn't clear on it, but specifically, GET requests don't usually send bodies;
             # if they don't, sending Content-Length:0 can cause issues.
-            unless datum[:method].to_s.casecmp('GET') == 0 && body.nil?
+            unless datum[:method].to_s.casecmp?('GET') && body.nil?
               unless datum[:headers].has_key?('Content-Length')
                 datum[:headers]['Content-Length'] = detect_content_length(body)
               end
@@ -250,7 +250,7 @@ module Excon
         datum[:headers]['Authorization'] ||= 'Basic ' + ["#{user}:#{pass}"].pack('m').delete(Excon::CR_NL)
       end
 
-      host_key = datum[:headers].keys.detect {|k| k.casecmp('Host') == 0 } || 'Host'
+      host_key = datum[:headers].keys.detect {|k| k.casecmp?('Host') } || 'Host'
       if datum[:scheme] == UNIX
         datum[:headers][host_key] ||= ''
       else
@@ -298,8 +298,8 @@ module Excon
         @persistent_socket_reusable = true
 
         if datum[:persistent]
-          if (key = datum[:response][:headers].keys.detect {|k| k.casecmp('Connection') == 0 })
-            if datum[:response][:headers][key].casecmp('close') == 0
+          if (key = datum[:response][:headers].keys.detect {|k| k.casecmp?('Connection') })
+            if datum[:response][:headers][key].casecmp?('close')
               reset
             end
           end
@@ -338,8 +338,8 @@ module Excon
       end
 
       if @data[:persistent]
-        if (key = responses.last[:headers].keys.detect {|k| k.casecmp('Connection') == 0 })
-          if responses.last[:headers][key].casecmp('close') == 0
+        if (key = responses.last[:headers].keys.detect {|k| k.casecmp?('Connection') })
+          if responses.last[:headers][key].casecmp?('close')
             reset
           end
         end

--- a/lib/excon/middlewares/capture_cookies.rb
+++ b/lib/excon/middlewares/capture_cookies.rb
@@ -9,7 +9,7 @@ module Excon
 
       def get_header(datum, header)
         _, header_value = datum[:response][:headers].detect do |key, _|
-          key.casecmp(header) == 0
+          key.casecmp?(header)
         end
         header_value
       end

--- a/lib/excon/middlewares/redirect_follower.rb
+++ b/lib/excon/middlewares/redirect_follower.rb
@@ -17,7 +17,7 @@ module Excon
 
       def get_header(datum, header)
         _, header_value = datum[:response][:headers].detect do |key, _|
-          key.casecmp(header) == 0
+          key.casecmp?(header)
         end
         header_value
       end

--- a/lib/excon/response.rb
+++ b/lib/excon/response.rb
@@ -106,9 +106,9 @@ module Excon
 
       unless (['HEAD', 'CONNECT'].include?(datum[:method].to_s.upcase)) || NO_ENTITY.include?(datum[:response][:status])
 
-        if (key = datum[:response][:headers].keys.detect {|k| k.casecmp('Transfer-Encoding') == 0 })
+        if (key = datum[:response][:headers].keys.detect {|k| k.casecmp?('Transfer-Encoding') })
           encodings = Utils.split_header_value(datum[:response][:headers][key])
-          if (encoding = encodings.last) && encoding.casecmp('chunked') == 0
+          if (encoding = encodings.last) && encoding.casecmp?('chunked')
             transfer_encoding_chunked = true
             if encodings.length == 1
               datum[:response][:headers].delete(key)
@@ -156,7 +156,7 @@ module Excon
           end
           parse_headers(socket, datum) # merge trailers into headers
         else
-          if (key = datum[:response][:headers].keys.detect {|k| k.casecmp('Content-Length') == 0 })
+          if (key = datum[:response][:headers].keys.detect {|k| k.casecmp?('Content-Length') })
             content_length = datum[:response][:headers][key].to_i
           end
 
@@ -202,7 +202,7 @@ module Excon
           raise Excon::Error::ResponseParse, 'malformed header' unless value
           # add key/value or append value to existing values
           datum[:response][:headers][key] = ([datum[:response][:headers][key]] << value.strip).compact.join(', ')
-          if key.casecmp('Set-Cookie') == 0
+          if key.casecmp?('Set-Cookie')
             datum[:response][:cookies] << value.strip
           end
           last_key = key

--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -87,8 +87,8 @@ module Excon
     end
 
     def default_port?(datum)
-      (datum[:scheme].casecmp('http').zero? && datum[:port] == 80) ||
-        (datum[:scheme].casecmp('https').zero? && datum[:port] == 443)
+      (datum[:scheme].casecmp?('http') && datum[:port] == 80) ||
+        (datum[:scheme].casecmp?('https') && datum[:port] == 443)
     end
 
     def query_string(datum)


### PR DESCRIPTION
This has the same resulting value, but is easier to read. It's available in Ruby 2.7, which is currently the oldest required version.