### PR TITLE
Allow Excon::Connection to be instantiated without parameters

### DIFF
--- a/lib/excon/utils.rb
+++ b/lib/excon/utils.rb
@@ -87,8 +87,9 @@ module Excon
     end
 
     def default_port?(datum)
-      (datum[:scheme].casecmp?('http') && datum[:port] == 80) ||
-        (datum[:scheme].casecmp?('https') && datum[:port] == 443)
+      (!datum[:scheme]&.casecmp?('unix') && datum[:port].nil?) ||
+        (datum[:scheme]&.casecmp?('http') && datum[:port] == 80) ||
+        (datum[:scheme]&.casecmp?('https') && datum[:port] == 443)
     end
 
     def query_string(datum)

--- a/tests/connection_tests.rb
+++ b/tests/connection_tests.rb
@@ -91,5 +91,9 @@ Shindo.tests('Excon Connection') do
     end
   end
 
+  test('initialization') do
+    !Excon::Connection.new.nil? # This should not raise
+  end
+
   env_restore
 end


### PR DESCRIPTION
Fixes #866 