### PR TITLE
Include port for CONNECT when include_default_port is used

### DIFF
--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -108,7 +108,7 @@ module Excon
       end
 
       if @data[:proxy]
-        request = "CONNECT #{@data[:host]}#{Excon::HTTP_1_1}" \
+        request = "CONNECT #{@data[:host]}#{port_string(@data)}#{Excon::HTTP_1_1}" \
                   "Host: #{@data[:host]}#{port_string(@data)}#{Excon::CR_NL}"
 
         if @data[:proxy].has_key?(:user) || @data[:proxy].has_key?(:password)


### PR DESCRIPTION
Thanks for this gem!

We're using http-based proxy (Fixie) to access secured URLs (https) and we stumbled upon an issue where version >= 1.0.0 is not able to read data - `EOFError` is raised.

I was able to pinpoint the problem to missing port in `CONNECT` directive. I've fixed the issue by respecting `include_default_port` when using `CONNECT` but I'm wondering if port should not be included there by default. WDYT?

I'd love to write a spec to cover this change but I'm not sure where to start. Would you be so kind to help me with that?