### PR TITLE
Handle read error from socket after "Broken pipe"

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -194,7 +194,7 @@ module Excon
           raise(error)
         when Errno::EPIPE
           # Read whatever remains in the pipe to aid in debugging
-          response = socket.read
+          response = socket.read rescue ""
           error = Excon::Error.new(response + error.message)
           raise_socket_error(error)
         else


### PR DESCRIPTION
Under certain circumstances it's not possible to read from the socket, this ensures we still propagate a `Excon::Error` even if `Excon::Socket#read` raises.

As the reproduction is a bit tricky (see #873) I am not sure how to design the test. First we need a `Errno::EPIPE` and then we also need it to error out on the socket read.

In general I try to avoid one-line rescues as they catch `StandardError` (very broad). In this case I think it's fine though, I have seen `Errno::ECONNRESET` and `OpenSSL::SSL::SSLError` being raised here and there are probably more things that could happen. Moreover, we are already quite nested and adding yet another begin/end block with explicit rescues may not be too aesthetically pleasing :). I also contemplated adding a method, something like `try_read_from_socket(socket)` but didn't feel it was worth the indirection.

Close #873.