### PR TITLE
Don't use rescue in modifier form with condition

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -181,7 +181,7 @@ module Excon
             socket.close rescue nil
           end
         rescue SystemCallError => exception
-          socket.close rescue nil if socket
+          socket&.close rescue nil
         end
       end
 

--- a/lib/excon/unix_socket.rb
+++ b/lib/excon/unix_socket.rb
@@ -34,7 +34,7 @@ module Excon
       end
 
     rescue => error
-      @socket.close rescue nil if @socket
+      @socket&.close rescue nil
       raise error
     end
 


### PR DESCRIPTION
This is actually parsed as `socket.close rescue (nil if socket)`. In practise this doesn't matter since it already swallows all errors, including the `NoMethodError` when the socket is actually nil.