### PR TITLE
Add ignore EOF constant to ignore OpenSSL EOF error

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -86,6 +86,7 @@ module Excon
     keepalive
     host
     hostname
+    ignore_unexpected_eof
     include_default_port
     omit_default_port
     nonblock

--- a/lib/excon/ssl_socket.rb
+++ b/lib/excon/ssl_socket.rb
@@ -26,6 +26,7 @@ module Excon
       if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
         ssl_context_options |= OpenSSL::SSL::OP_NO_COMPRESSION
       end
+      ssl_context_options |= OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF if @data[:ignore_unexpected_eof]
       ssl_context.options = ssl_context_options
 
       ssl_context.ciphers = @data[:ciphers]


### PR DESCRIPTION
We have this issue in Proxmox https://github.com/theforeman/foreman_fog_proxmox/issues/325, where Proxmox has open SSL connection which is not closed and results in  SSL routines::unexpected eof. This PR adds new constant which when set true ignores unexpected EOF in OpenSSL connection.