### PR TITLE
Add explicit dependency on Logger gem

### DIFF
--- a/excon.gemspec
+++ b/excon.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
   ]
   s.required_ruby_version = '>= 2.7.0'
 
+  s.add_dependency 'logger'
+
   s.add_development_dependency('activesupport')
   s.add_development_dependency('delorean')
   s.add_development_dependency('eventmachine', '>= 1.0.4')


### PR DESCRIPTION
Using this gem with Ruby 3.4 logs the following warning:

```ruby
~/.gem/ruby/3.4.2/gems/excon-1.2.4/lib/excon/instrumentors/logging_instrumentor.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```

This pull request adds an explicit dependency on the Logger gem for forward compatibility.