### PR TITLE
Fix error handling in tests

### DIFF
--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -337,7 +337,7 @@ end
 
 def wait_for_message(io, msg)
   process_stderr = ""
-  until (line = io.gets).include?(msg)
+  until (line = io.gets)&.include?(msg)
     # nil means we have reached the end of stream
     raise process_stderr if line.nil?
     process_stderr << line


### PR DESCRIPTION
Fixes test suite to give better diagnostics instead of failing with:

```
      undefined method `include?' for nil:NilClass (NoMethodError)
        tests/test_helper.rb:393:in `with_server'
        tests/request_tests.rb:6:in `block (3 levels) in <top (required)>'
        tests/request_tests.rb:5:in `each'
        tests/request_tests.rb:5:in `block (2 levels) in <top (required)>'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo.rb:79:in `instance_eval'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo.rb:79:in `tests'
        tests/request_tests.rb:2:in `block in <top (required)>'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo.rb:79:in `instance_eval'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo.rb:79:in `tests'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo.rb:38:in `initialize'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo.rb:13:in `new'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo.rb:13:in `tests'
        tests/request_tests.rb:1:in `<top (required)>'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo/bin.rb:61:in `load'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo/bin.rb:61:in `block (2 levels) in run_in_thread'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo/bin.rb:58:in `each'
        /var/lib/gems/3.2.0/gems/shindo-0.3.11/lib/shindo/bin.rb:58:in `block in run_in_thread'
```

Initially spotted in #879.