### PR TITLE
Replace magic number with signal name

### DIFF
--- a/benchmarks/excon.rb
+++ b/benchmarks/excon.rb
@@ -40,7 +40,7 @@ def with_server(&block)
   end
   yield
 ensure
-  Process.kill(9, pid)
+  Process.kill('KILL', pid)
 end
 
 require 'tach'

--- a/benchmarks/excon_vs.rb
+++ b/benchmarks/excon_vs.rb
@@ -40,7 +40,7 @@ def with_server(&block)
   end
   yield
 ensure
-  Process.kill(9, pid)
+  Process.kill('KILL', pid)
 end
 
 require 'em-http-request'

--- a/benchmarks/vs_stdlib.rb
+++ b/benchmarks/vs_stdlib.rb
@@ -36,7 +36,7 @@ def with_server(&block)
   end
   yield
 ensure
-  Process.kill(9, pid)
+  Process.kill('KILL', pid)
 end
 
 require 'net/http'

--- a/lib/excon/test/server.rb
+++ b/lib/excon/test/server.rb
@@ -50,7 +50,7 @@ module Excon
         if RUBY_PLATFORM == 'java'
           Process.kill('USR1', pid)
         else
-          Process.kill(9, pid)
+          Process.kill('KILL', pid)
           Process.wait(pid)
         end
 

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -325,7 +325,7 @@ def launch_process(*args)
 end
 
 def cleanup_process(pid)
-  Process.kill(9, pid)
+  Process.kill('KILL', pid)
   unless RUBY_PLATFORM == 'java'
     Process.wait(pid)
   end


### PR DESCRIPTION
It's easier to read code without magic numbers.