### PR TITLE
Fix webmock to extend the connection keys

### DIFF
--- a/lib/excon/constants.rb
+++ b/lib/excon/constants.rb
@@ -111,7 +111,7 @@ module Excon
     tcp_nodelay
     thread_safe_sockets
     uri_parser
-  ]).freeze
+  ])
 
   DEPRECATED_VALID_REQUEST_KEYS = {
     captures: 'Mock',


### PR DESCRIPTION
webmock tries to extend the frozen VALID_CONNECTION_KEYS which, of course doesn't work.
Therefore, projects using webmock and excon >= 1.2.6 fail.

See: https://github.com/bblimke/webmock/blob/master/lib/webmock/http_lib_adapters/excon_adapter.rb#L166C10-L166C31
See: https://github.com/excon/excon/commit/fe8122975fe73eeb9d7937ffff0207a5692b004a#r158134459