### PR TITLE
Require cgi/escape instead of cgi

### DIFF
--- a/lib/excon.rb
+++ b/lib/excon.rb
@@ -3,7 +3,7 @@
 $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
-require 'cgi'
+require 'cgi/escape'
 require 'forwardable'
 require 'ipaddr'
 require 'openssl'


### PR DESCRIPTION
excon does not have a dependency on cgi. If you have excon in your Gemfile, but not cgi, there is a verbose mode warning when requiring excon on Ruby 4.0. Example file:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'excon'
end

require "excon"
```

Running in verbose mode:

```
$ ruby -v t.rb
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [x86_64-linux]
/home/jeremy/.local/share/mise/installs/ruby/4.0.2/lib/ruby/gems/4.0.0/gems/excon-1.4.0/lib/excon.rb:6: warning: CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
```

It appears the only CGI method used is CGI.escape, so as the warning output recommends, this switches to requiring cgi/escape.

`cgi/escape` adding `CGI.escape` has been true since Ruby 2.4, and Excon supports Ruby 3.1+, so there shouldn't be backwards compatibility issues.