### PR TITLE
Raise Excon::Error::InvalidParameter when host is nil

### DIFF
--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -102,6 +102,10 @@ module Excon
           @socket_key = "#{@data[:scheme]}://#{@data[:socket]}"
         end
       else
+        if @data.key?(:host) && @data[:host].nil?
+          raise Excon::Error::InvalidParameter, "host is required for non-Unix connections; " \
+                                                "the URL may be malformed (e.g. missing \"//\" after the scheme)"
+        end
         @socket_key = "#{@data[:scheme]}://#{@data[:host]}#{port_string(@data)}"
       end
       reset
@@ -256,6 +260,10 @@ module Excon
       if datum[:scheme] == UNIX
         datum[:headers][host_key] ||= ''
       else
+        if datum[:host].nil?
+          raise Excon::Error::InvalidParameter, "host is required for non-Unix connections; " \
+                                                "the URL may be malformed (e.g. missing \"//\" after the scheme)"
+        end
         datum[:headers][host_key] ||= datum[:host] + port_string(datum)
       end
 

--- a/lib/excon/error.rb
+++ b/lib/excon/error.rb
@@ -48,6 +48,7 @@ or:
 
     class InvalidHeaderKey < Error; end
     class InvalidHeaderValue < Error; end
+    class InvalidParameter < Error; end
     class Timeout < Error; end
     class ResponseParse < Error; end
 

--- a/tests/error_tests.rb
+++ b/tests/error_tests.rb
@@ -39,6 +39,33 @@ Shindo.tests('HTTPStatusError request/response debugging') do
     end
   end
 
+  tests('new raises Excon::Error::InvalidParameter for URL with nil host (missing //)').returns(true) do
+    begin
+      Excon.new('https:/registry.example.com/package')
+      false
+    rescue Excon::Error::InvalidParameter => e
+      e.message.include?('host is required')
+    end
+  end
+
+  tests('new raises Excon::Error::InvalidParameter when host: nil overrides a valid URL').returns(true) do
+    begin
+      Excon.new('https://registry.example.com/package', host: nil)
+      false
+    rescue Excon::Error::InvalidParameter => e
+      e.message.include?('host is required')
+    end
+  end
+
+  tests('new raises Excon::Error::InvalidParameter for Connection.new without host').returns(true) do
+    begin
+      Excon::Connection.new(scheme: 'https', path: '/package', port: 443).get
+      false
+    rescue Excon::Error::InvalidParameter => e
+      e.message.include?('host is required')
+    end
+  end
+
   tests('can raise standard error and catch standard error').returns(true) do
     begin 
       raise Excon::Error::Client.new('foo')


### PR DESCRIPTION
## Summary

- Adds `Excon::Error::InvalidParameter` to the error hierarchy (alongside `InvalidHeaderKey`/`InvalidHeaderValue`)
- Raises it early in `Connection#initialize` when `:host` is explicitly set to `nil` (malformed URL, explicit `host: nil` override)
- Raises it in `Connection#request` when `datum[:host]` is nil at request time (connection built without a host key)
- Adds 3 tests covering all trigger paths from issue #899

## Why `Excon::Error::InvalidParameter` and not `ArgumentError`

Users rescue `Excon::Error` to catch library failures. An `ArgumentError` would silently escape that rescue block, making the nil-host case impossible to handle consistently alongside network errors.

## Test plan

- [x] `Excon.new('https:/registry.example.com/package')` → raises `Excon::Error::InvalidParameter`
- [x] `Excon.new('https://example.com', host: nil)` → raises `Excon::Error::InvalidParameter`
- [x] `Excon::Connection.new(scheme: 'https', path: '/package', port: 443).get` → raises `Excon::Error::InvalidParameter`
- [x] `Excon::Connection.new` (no args) → still does not raise (existing `initialization` test preserved)
- [x] Full test suite: `12 pending and 1471 succeeded`, no failures

Closes #899