### PR TITLE
Introduce read_buffer_scratch

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -52,7 +52,8 @@ module Excon
       @data = data
       @nonblock = data[:nonblock]
       @port ||= @data[:port] || 80
-      @read_buffer = String.new
+      @read_buffer = String.new(encoding: Encoding::BINARY)
+      @read_buffer_scratch = String.new(encoding: Encoding::BINARY)
       @read_offset = 0
       @eof = false
       @backend_eof = false
@@ -239,7 +240,7 @@ module Excon
               # Avoid allocating a new buffer string when the read buffer is empty
               @read_buffer = @socket.read_nonblock(max_length, @read_buffer)
             else
-              @read_buffer << @socket.read_nonblock(max_length - readable_bytes)
+              @read_buffer << @socket.read_nonblock(max_length - readable_bytes, @read_buffer_scratch)
             end
           end
         else
@@ -248,7 +249,7 @@ module Excon
               # Avoid allocating a new buffer string when the read buffer is empty
               @read_buffer = @socket.read_nonblock(@data[:chunk_size], @read_buffer)
             else
-              @read_buffer << @socket.read_nonblock(@data[:chunk_size])
+              @read_buffer << @socket.read_nonblock(@data[:chunk_size], @read_buffer_scratch)
             end
           end
         end

--- a/tests/socket_tests.rb
+++ b/tests/socket_tests.rb
@@ -25,14 +25,18 @@ end
 # A socket whose read_nonblock returns from an input list,
 # and which counts the number of reads
 class MockNonblockRubySocket
-  attr_reader :sequence
+  attr_reader :out_buffers, :sequence
 
-  def initialize(nonblock_reads)
+  def initialize(nonblock_reads, max_read_size = nil)
+    @max_read_size = max_read_size || Float::INFINITY
     @nonblock_reads = nonblock_reads
+    @out_buffers = []
     @sequence = []
   end
 
   def read_nonblock(maxlen, buffer = nil)
+    @out_buffers << buffer
+
     if @nonblock_reads.empty?
       @sequence << 'EOF'
       raise EOFError
@@ -44,8 +48,8 @@ class MockNonblockRubySocket
       end
       @sequence << 'EAGAIN'
       raise Errno::EAGAIN
-    elsif
-      len = maxlen ? maxlen : @nonblock_reads.first.length
+    else
+      len = [maxlen || @nonblock_reads.first.length, @max_read_size].min
       ret = @nonblock_reads.first.slice!(0, len)
       @sequence << ret.length
 
@@ -117,5 +121,29 @@ Shindo.tests('socket') do
         end
       end
     end
+  end
+
+  tests('read(max_length) reuses a binary append buffer').returns(true) do
+    backend_socket = MockNonblockRubySocket.new(["abcd\xFFf".b], 2)
+    socket = MockExconSocket.new(backend_socket, nonblock: true)
+    result = socket.read(6)
+    append_buffers = backend_socket.out_buffers[1..]
+    scratch = append_buffers.first
+
+    result == "abcd\xFFf".b && result.encoding == Encoding::BINARY &&
+      append_buffers.length == 2 &&
+      append_buffers.all? { |buffer| buffer && buffer.equal?(scratch) && buffer.encoding == Encoding::BINARY }
+  end
+
+  tests('read(nil) reuses a binary append buffer').returns(true) do
+    backend_socket = MockNonblockRubySocket.new(["ab\xFF".b], 2)
+    socket = MockExconSocket.new(backend_socket, nonblock: true, chunk_size: 512)
+    result = socket.read(nil)
+    append_buffers = backend_socket.out_buffers[1..]
+    scratch = append_buffers.first
+
+    result == "ab\xFF".b &&
+      append_buffers.length == 2 &&
+      append_buffers.all? { |buffer| buffer && buffer.equal?(scratch) && buffer.encoding == Encoding::BINARY }
   end
 end


### PR DESCRIPTION
Hello
Recently, I upgraded one of the apps to Ruby 4 and instantly noticed a huge memory increase. After digging, I found out that for some reason, strings created by reading data from sockets without a buffer are not being cleared by the GC (no idea what changed in Ruby 3->4). I fixed the issue by adding an additional buffer that is used when the main one is not empty, instead of creating new objects on every read. In my case, it reduced memory usage by 30% on instances that use excon to ingest data from APIs.

Env: Ruby 4.0.5, Alpine 3.24.1, jemalloc 5.3.0