### PR TITLE
Fix incorrect variable name

### DIFF
--- a/lib/excon/socket.rb
+++ b/lib/excon/socket.rb
@@ -298,7 +298,7 @@ module Excon
     rescue OpenSSL::SSL::SSLError => e
       select_with_timeout(@socket, :read) && retry if e.message == 'read would block'
 
-      raise(error)
+      raise(e)
     rescue *READ_RETRY_EXCEPTION_CLASSES
       select_with_timeout(@socket, :read) && retry
     rescue EOFError

--- a/tests/socket_tests.rb
+++ b/tests/socket_tests.rb
@@ -69,7 +69,22 @@ class MockNonblockRubySocket
   end
 end
 
+class MockBlockingRubySocket
+  def initialize(error)
+    @error = error
+  end
+
+  def read(_max_length)
+    raise @error
+  end
+end
+
 Shindo.tests('socket') do
+  tests('read_block re-raises SSL errors').raises(OpenSSL::SSL::SSLError) do
+    error = OpenSSL::SSL::SSLError.new('SSL error')
+    MockExconSocket.new(MockBlockingRubySocket.new(error)).read
+  end
+
   CHUNK_SIZES = [nil, 512]
   CHUNK_SIZES.each do |chunk_size|
     tests("chunk_size: #{chunk_size}") do


### PR DESCRIPTION
Avoid a NameError but properly passing variable "e" instead of non-existing "error".