### PR TITLE
Use weak keys for thread-safe socket caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', '4.0', 'head', 'jruby']
+        ruby-version: ['3.3', '3.4', '4.0', 'head', 'jruby']
     timeout-minutes: 5
 
     steps:

--- a/excon.gemspec
+++ b/excon.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     'README.md',
     'excon.gemspec'
   ]
-  s.required_ruby_version = '>= 3.1.0'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.add_dependency 'logger'
 

--- a/lib/excon/connection.rb
+++ b/lib/excon/connection.rb
@@ -508,22 +508,21 @@ module Excon
     end
 
     def sockets
-      @_excon_sockets ||= {}
-      @_excon_sockets.compare_by_identity
-
       if @pid != Process.pid
-        @_excon_sockets.clear # GC will take care of closing sockets
+        @_excon_sockets&.clear # GC will take care of closing sockets
         @pid = Process.pid
       end
 
       if @data[:thread_safe_sockets]
+        @_excon_sockets ||= ObjectSpace::WeakKeyMap.new
+
         # In a multi-threaded world, if the same connection is used by multiple
         # threads at the same time to connect to the same destination, they may
         # stomp on each other's sockets.  This ensures every thread gets their
         # own socket cache, within the context of a single connection.
         @_excon_sockets[Thread.current] ||= {}
       else
-        @_excon_sockets
+        @_excon_sockets ||= {}.compare_by_identity
       end
     end
 


### PR DESCRIPTION
Hello again,
I have another memory optimization change that would solve https://github.com/excon/excon/issues/651. Using `WeakKeyMap` would allow the GC to clear sockets for threads that no longer exist. Unfortunately, it was introduced in Ruby 3.3. I'm not sure if it's ok to bump the required version, although 3.2 already reached EOL